### PR TITLE
Use shared Go bootstrap action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: evalops/service-runtime/.github/actions/setup-go-service@43efc41af087e5ebd62bffdeb5ca42ccfa44438c
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: evalops/service-runtime/.github/actions/setup-go-service@43efc41af087e5ebd62bffdeb5ca42ccfa44438c
+        uses: evalops/service-runtime/.github/actions/setup-go-service@ca09da8302203b96582332dbcababe9f2d906d10
         with:
           go-version-file: go.mod
           cache: true

--- a/internal/app/proxy_browser_test.go
+++ b/internal/app/proxy_browser_test.go
@@ -19,7 +19,7 @@ func TestService_ExecuteGitHubProxy(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := testNow()
 	repo := memstore.NewRepository()
 	runtime := memstore.NewRuntimeStore()
 	tools := toolregistry.New()
@@ -135,7 +135,7 @@ func TestService_RegisterBrowserRelayAndUnwrapArtifact(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := testNow()
 	repo := memstore.NewRepository()
 	runtime := memstore.NewRuntimeStore()
 	tools := toolregistry.New()

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -20,7 +20,7 @@ func TestService_CreateSessionAndIssueProxyGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := testNow()
 	repo := memstore.NewRepository()
 	auditSink := memory.NewSink()
 	tools := toolregistry.New()
@@ -146,7 +146,7 @@ func TestService_BrowserGrantRequiresApprovalBeforeIssue(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := testNow()
 	repo := memstore.NewRepository()
 	auditSink := memory.NewSink()
 	tools := toolregistry.New()
@@ -269,7 +269,7 @@ func TestService_RevokeSessionRevokesOutstandingGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := testNow()
 	repo := memstore.NewRepository()
 	tools := toolregistry.New()
 	engine := policy.NewEngine()
@@ -388,6 +388,10 @@ func mustNewSigner(t *testing.T) core.SessionTokenManager {
 	}
 
 	return signer
+}
+
+func testNow() time.Time {
+	return time.Now().UTC().Truncate(time.Second)
 }
 
 func mustPutTool(t *testing.T, ctx context.Context, registry *toolregistry.Registry, tool core.Tool) {

--- a/internal/connectors/github/app_token_source_test.go
+++ b/internal/connectors/github/app_token_source_test.go
@@ -20,7 +20,7 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 
 	installationLookups := 0
 	tokenRequests := 0
@@ -37,7 +37,7 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 			_, _ = w.Write([]byte(`{"id":987}`))
 		case "/app/installations/987/access_tokens":
 			tokenRequests++
-			_, _ = w.Write([]byte(`{"token":"inst-token","expires_at":"2026-03-12T20:10:00Z"}`))
+			_, _ = w.Write([]byte(`{"token":"inst-token","expires_at":"` + now.Add(10*time.Minute).Format(time.RFC3339) + `"}`))
 		default:
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}


### PR DESCRIPTION
## Summary
- replace the direct setup-go step with evalops/service-runtime/.github/actions/setup-go-service@43efc41af087e5ebd62bffdeb5ca42ccfa44438c
- preserve the existing repo-specific CI knobs while centralizing the Go bootstrap contract

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check\n- go build ./...