### PR TITLE
Harden ASB HTTP request handling

### DIFF
--- a/cmd/asb-api/config.go
+++ b/cmd/asb-api/config.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+type serverConfig struct {
+	addr           string
+	maxBodyBytes   int64
+	readTimeout    time.Duration
+	writeTimeout   time.Duration
+	idleTimeout    time.Duration
+	defaultTimeout time.Duration
+	grantTimeout   time.Duration
+	proxyTimeout   time.Duration
+}
+
+func loadServerConfig() (serverConfig, error) {
+	cfg := serverConfig{
+		addr:           getenv("ASB_ADDR", ":8080"),
+		maxBodyBytes:   1 << 20,
+		readTimeout:    10 * time.Second,
+		writeTimeout:   30 * time.Second,
+		idleTimeout:    120 * time.Second,
+		defaultTimeout: 10 * time.Second,
+		grantTimeout:   20 * time.Second,
+		proxyTimeout:   30 * time.Second,
+	}
+
+	var err error
+	if cfg.maxBodyBytes, err = parsePositiveInt64Env("ASB_HTTP_MAX_BODY_BYTES", cfg.maxBodyBytes); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.readTimeout, err = parsePositiveDurationEnv("ASB_HTTP_READ_TIMEOUT", cfg.readTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.writeTimeout, err = parsePositiveDurationEnv("ASB_HTTP_WRITE_TIMEOUT", cfg.writeTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.idleTimeout, err = parsePositiveDurationEnv("ASB_HTTP_IDLE_TIMEOUT", cfg.idleTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.defaultTimeout, err = parsePositiveDurationEnv("ASB_HTTP_DEFAULT_TIMEOUT", cfg.defaultTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.grantTimeout, err = parsePositiveDurationEnv("ASB_HTTP_GRANT_TIMEOUT", cfg.grantTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.proxyTimeout, err = parsePositiveDurationEnv("ASB_HTTP_PROXY_TIMEOUT", cfg.proxyTimeout); err != nil {
+		return serverConfig{}, err
+	}
+
+	return cfg, nil
+}
+
+func parsePositiveDurationEnv(key string, fallback time.Duration) (time.Duration, error) {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+	return value, nil
+}
+
+func parsePositiveInt64Env(key string, fallback int64) (int64, error) {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+	return value, nil
+}

--- a/cmd/asb-api/config_test.go
+++ b/cmd/asb-api/config_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadServerConfigDefaults(t *testing.T) {
+	t.Setenv("ASB_ADDR", "")
+	t.Setenv("ASB_HTTP_MAX_BODY_BYTES", "")
+	t.Setenv("ASB_HTTP_READ_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_WRITE_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_IDLE_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_DEFAULT_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_GRANT_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_PROXY_TIMEOUT", "")
+
+	cfg, err := loadServerConfig()
+	if err != nil {
+		t.Fatalf("loadServerConfig() error = %v", err)
+	}
+	if cfg.addr != ":8080" {
+		t.Fatalf("addr = %q, want %q", cfg.addr, ":8080")
+	}
+	if cfg.maxBodyBytes != 1<<20 {
+		t.Fatalf("maxBodyBytes = %d, want %d", cfg.maxBodyBytes, 1<<20)
+	}
+	if cfg.readTimeout != 10*time.Second || cfg.writeTimeout != 30*time.Second || cfg.idleTimeout != 120*time.Second {
+		t.Fatalf("unexpected server timeouts: %#v", cfg)
+	}
+}
+
+func TestLoadServerConfigParsesOverrides(t *testing.T) {
+	t.Setenv("ASB_ADDR", ":9090")
+	t.Setenv("ASB_HTTP_MAX_BODY_BYTES", "2048")
+	t.Setenv("ASB_HTTP_READ_TIMEOUT", "11s")
+	t.Setenv("ASB_HTTP_WRITE_TIMEOUT", "41s")
+	t.Setenv("ASB_HTTP_IDLE_TIMEOUT", "2m")
+	t.Setenv("ASB_HTTP_DEFAULT_TIMEOUT", "9s")
+	t.Setenv("ASB_HTTP_GRANT_TIMEOUT", "29s")
+	t.Setenv("ASB_HTTP_PROXY_TIMEOUT", "45s")
+
+	cfg, err := loadServerConfig()
+	if err != nil {
+		t.Fatalf("loadServerConfig() error = %v", err)
+	}
+	if cfg.addr != ":9090" || cfg.maxBodyBytes != 2048 {
+		t.Fatalf("unexpected basic config: %#v", cfg)
+	}
+	if cfg.readTimeout != 11*time.Second || cfg.writeTimeout != 41*time.Second || cfg.idleTimeout != 2*time.Minute {
+		t.Fatalf("unexpected server timeouts: %#v", cfg)
+	}
+	if cfg.defaultTimeout != 9*time.Second || cfg.grantTimeout != 29*time.Second || cfg.proxyTimeout != 45*time.Second {
+		t.Fatalf("unexpected request timeouts: %#v", cfg)
+	}
+}
+
+func TestLoadServerConfigRejectsInvalidValues(t *testing.T) {
+	t.Setenv("ASB_HTTP_MAX_BODY_BYTES", "0")
+
+	if _, err := loadServerConfig(); err == nil {
+		t.Fatal("loadServerConfig() error = nil, want non-nil")
+	}
+}

--- a/cmd/asb-api/main.go
+++ b/cmd/asb-api/main.go
@@ -22,9 +22,18 @@ func main() {
 	}
 	defer cleanup()
 
-	addr := getenv("ASB_ADDR", ":8080")
+	cfg, err := loadServerConfig()
+	if err != nil {
+		logger.Error("load server config", "error", err)
+		os.Exit(1)
+	}
+
 	mux := http.NewServeMux()
-	mux.Handle("/v1/", httpapi.NewServer(svc))
+	mux.Handle("/v1/", httpapi.NewServer(
+		svc,
+		httpapi.WithMaxBodyBytes(cfg.maxBodyBytes),
+		httpapi.WithRequestTimeouts(cfg.defaultTimeout, cfg.grantTimeout, cfg.proxyTimeout),
+	))
 	connectPath, connectHandler := connectapi.NewHandler(svc)
 	mux.Handle(connectPath, connectHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -32,8 +41,25 @@ func main() {
 		_, _ = w.Write([]byte("ok"))
 	})
 
-	logger.Info("starting asb api", "addr", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	server := &http.Server{
+		Addr:         cfg.addr,
+		Handler:      mux,
+		ReadTimeout:  cfg.readTimeout,
+		WriteTimeout: cfg.writeTimeout,
+		IdleTimeout:  cfg.idleTimeout,
+	}
+
+	logger.Info("starting asb api",
+		"addr", cfg.addr,
+		"max_body_bytes", cfg.maxBodyBytes,
+		"read_timeout", cfg.readTimeout,
+		"write_timeout", cfg.writeTimeout,
+		"idle_timeout", cfg.idleTimeout,
+		"default_timeout", cfg.defaultTimeout,
+		"grant_timeout", cfg.grantTimeout,
+		"proxy_timeout", cfg.proxyTimeout,
+	)
+	if err := server.ListenAndServe(); err != nil {
 		logger.Error("server exited", "error", err)
 		os.Exit(1)
 	}

--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -25,11 +26,64 @@ type Service interface {
 }
 
 type Server struct {
-	service Service
+	service  Service
+	maxBody  int64
+	timeouts requestTimeouts
 }
 
-func NewServer(service Service) *Server {
-	return &Server{service: service}
+type Option func(*Server)
+
+type requestTimeouts struct {
+	defaultTimeout time.Duration
+	grantTimeout   time.Duration
+	proxyTimeout   time.Duration
+}
+
+const (
+	defaultMaxBodyBytes   int64         = 1 << 20
+	defaultRequestTimeout time.Duration = 10 * time.Second
+	defaultGrantTimeout   time.Duration = 20 * time.Second
+	defaultProxyTimeout   time.Duration = 30 * time.Second
+)
+
+var errUnsupportedContentType = errors.New("content-type must be application/json")
+
+func NewServer(service Service, options ...Option) *Server {
+	server := &Server{
+		service: service,
+		maxBody: defaultMaxBodyBytes,
+		timeouts: requestTimeouts{
+			defaultTimeout: defaultRequestTimeout,
+			grantTimeout:   defaultGrantTimeout,
+			proxyTimeout:   defaultProxyTimeout,
+		},
+	}
+	for _, option := range options {
+		option(server)
+	}
+	return server
+}
+
+func WithMaxBodyBytes(limit int64) Option {
+	return func(server *Server) {
+		if limit > 0 {
+			server.maxBody = limit
+		}
+	}
+}
+
+func WithRequestTimeouts(defaultTimeout time.Duration, grantTimeout time.Duration, proxyTimeout time.Duration) Option {
+	return func(server *Server) {
+		if defaultTimeout > 0 {
+			server.timeouts.defaultTimeout = defaultTimeout
+		}
+		if grantTimeout > 0 {
+			server.timeouts.grantTimeout = grantTimeout
+		}
+		if proxyTimeout > 0 {
+			server.timeouts.proxyTimeout = proxyTimeout
+		}
+	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -37,23 +91,23 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/sessions":
-		s.handleCreateSession(w, r)
+		s.handleCreateSession(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/grants":
-		s.handleRequestGrant(w, r)
+		s.handleRequestGrant(w, s.withTimeout(r, s.timeouts.grantTimeout))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/approvals/") && strings.HasSuffix(r.URL.Path, ":approve"):
-		s.handleApproveGrant(w, r)
+		s.handleApproveGrant(w, s.withTimeout(r, s.timeouts.grantTimeout))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/approvals/") && strings.HasSuffix(r.URL.Path, ":deny"):
-		s.handleDenyGrant(w, r)
+		s.handleDenyGrant(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/grants/") && strings.HasSuffix(r.URL.Path, ":revoke"):
-		s.handleRevokeGrant(w, r)
+		s.handleRevokeGrant(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/sessions/") && strings.HasSuffix(r.URL.Path, ":revoke"):
-		s.handleRevokeSession(w, r)
+		s.handleRevokeSession(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/proxy/github/rest":
-		s.handleExecuteGitHubProxy(w, r)
+		s.handleExecuteGitHubProxy(w, s.withTimeout(r, s.timeouts.proxyTimeout))
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/browser/relay-sessions":
-		s.handleRegisterBrowserRelay(w, r)
+		s.handleRegisterBrowserRelay(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/artifacts/") && strings.HasSuffix(r.URL.Path, ":unwrap"):
-		s.handleUnwrapArtifact(w, r)
+		s.handleUnwrapArtifact(w, s.withTimeout(r, s.timeouts.defaultTimeout))
 	default:
 		http.NotFound(w, r)
 	}
@@ -61,7 +115,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	var req createSessionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -91,7 +145,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRequestGrant(w http.ResponseWriter, r *http.Request) {
 	var req requestGrantRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -115,7 +169,7 @@ func (s *Server) handleRequestGrant(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleApproveGrant(w http.ResponseWriter, r *http.Request) {
 	var req approvalDecisionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -136,7 +190,7 @@ func (s *Server) handleApproveGrant(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleDenyGrant(w http.ResponseWriter, r *http.Request) {
 	var req approvalDecisionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -156,7 +210,7 @@ func (s *Server) handleDenyGrant(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRevokeGrant(w http.ResponseWriter, r *http.Request) {
 	var req revokeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := s.decodeJSON(w, r, &req); err != nil && !errors.Is(err, io.EOF) {
 		writeError(w, err)
 		return
 	}
@@ -174,7 +228,7 @@ func (s *Server) handleRevokeGrant(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRevokeSession(w http.ResponseWriter, r *http.Request) {
 	var req revokeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := s.decodeJSON(w, r, &req); err != nil && !errors.Is(err, io.EOF) {
 		writeError(w, err)
 		return
 	}
@@ -192,7 +246,7 @@ func (s *Server) handleRevokeSession(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleExecuteGitHubProxy(w http.ResponseWriter, r *http.Request) {
 	var req executeGitHubProxyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -213,7 +267,7 @@ func (s *Server) handleExecuteGitHubProxy(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleRegisterBrowserRelay(w http.ResponseWriter, r *http.Request) {
 	var req registerBrowserRelayRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -238,7 +292,7 @@ func (s *Server) handleRegisterBrowserRelay(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) handleUnwrapArtifact(w http.ResponseWriter, r *http.Request) {
 	var req unwrapArtifactRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSON(w, r, &req); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -290,7 +344,14 @@ func writeError(w http.ResponseWriter, err error) {
 	status := http.StatusInternalServerError
 	var syntaxErr *json.SyntaxError
 	var typeErr *json.UnmarshalTypeError
+	var maxBytesErr *http.MaxBytesError
 	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		status = http.StatusGatewayTimeout
+	case errors.Is(err, errUnsupportedContentType):
+		status = http.StatusUnsupportedMediaType
+	case errors.As(err, &maxBytesErr):
+		status = http.StatusRequestEntityTooLarge
 	case errors.As(err, &syntaxErr), errors.As(err, &typeErr), errors.Is(err, io.EOF):
 		status = http.StatusBadRequest
 	case errors.Is(err, core.ErrInvalidRequest):
@@ -303,6 +364,59 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusNotFound
 	}
 	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func (s *Server) withTimeout(r *http.Request, timeout time.Duration) *http.Request {
+	if timeout <= 0 {
+		return r
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	return r.Clone(context.WithValue(ctx, requestCancelKey{}, cancel))
+}
+
+func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, out any) error {
+	defer s.finishRequest(r)
+
+	if err := requireJSONContentType(r); err != nil {
+		return err
+	}
+
+	body := http.MaxBytesReader(w, r.Body, s.maxBody)
+	defer body.Close()
+
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return errors.New("request body must contain a single JSON object")
+	}
+	return nil
+}
+
+type requestCancelKey struct{}
+
+func (s *Server) finishRequest(r *http.Request) {
+	cancel, _ := r.Context().Value(requestCancelKey{}).(context.CancelFunc)
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func requireJSONContentType(r *http.Request) error {
+	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if contentType == "" {
+		return errUnsupportedContentType
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return errUnsupportedContentType
+	}
+	if mediaType != "application/json" {
+		return errUnsupportedContentType
+	}
+	return nil
 }
 
 type createSessionRequest struct {

--- a/internal/api/httpapi/server_test.go
+++ b/internal/api/httpapi/server_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +104,61 @@ func TestServer_RequestGrant(t *testing.T) {
 	}
 	if payload["grant_id"] != "gr_123" {
 		t.Fatalf("grant_id = %v, want gr_123", payload["grant_id"])
+	}
+}
+
+func TestServer_RejectsUnsupportedContentType(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(&stubService{}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestServer_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{"tenant_id":"`+strings.Repeat("a", 256)+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(&stubService{}, httpapi.WithMaxBodyBytes(32)).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestServer_RequestTimeoutReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{
+		createSession: func(ctx context.Context, req *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{
+		"tenant_id":"t_acme",
+		"agent_id":"agent_pr_reviewer",
+		"run_id":"run_7f9",
+		"tool_context":["github"],
+		"attestation":{"kind":"k8s_sa_jwt","token":"jwt"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(svc, httpapi.WithRequestTimeouts(time.Nanosecond, time.Nanosecond, time.Nanosecond)).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusGatewayTimeout)
 	}
 }
 
@@ -246,37 +303,64 @@ type stubService struct {
 }
 
 func (s *stubService) CreateSession(ctx context.Context, req *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+	if s.createSession == nil {
+		return nil, errors.New("unexpected create session call")
+	}
 	return s.createSession(ctx, req)
 }
 
 func (s *stubService) RequestGrant(ctx context.Context, req *core.RequestGrantRequest) (*core.RequestGrantResponse, error) {
+	if s.requestGrant == nil {
+		return nil, errors.New("unexpected request grant call")
+	}
 	return s.requestGrant(ctx, req)
 }
 
 func (s *stubService) ApproveGrant(ctx context.Context, req *core.ApproveGrantRequest) (*core.RequestGrantResponse, error) {
+	if s.approveGrant == nil {
+		return nil, errors.New("unexpected approve grant call")
+	}
 	return s.approveGrant(ctx, req)
 }
 
 func (s *stubService) DenyGrant(ctx context.Context, req *core.DenyGrantRequest) error {
+	if s.denyGrant == nil {
+		return errors.New("unexpected deny grant call")
+	}
 	return s.denyGrant(ctx, req)
 }
 
 func (s *stubService) RevokeGrant(ctx context.Context, req *core.RevokeGrantRequest) error {
+	if s.revokeGrant == nil {
+		return errors.New("unexpected revoke grant call")
+	}
 	return s.revokeGrant(ctx, req)
 }
 
 func (s *stubService) RevokeSession(ctx context.Context, req *core.RevokeSessionRequest) error {
+	if s.revokeSession == nil {
+		return errors.New("unexpected revoke session call")
+	}
 	return s.revokeSession(ctx, req)
 }
 
 func (s *stubService) ExecuteGitHubProxy(ctx context.Context, req *core.ExecuteGitHubProxyRequest) (*core.ExecuteGitHubProxyResponse, error) {
+	if s.executeGitHubProxy == nil {
+		return nil, errors.New("unexpected execute github proxy call")
+	}
 	return s.executeGitHubProxy(ctx, req)
 }
 
 func (s *stubService) RegisterBrowserRelay(ctx context.Context, req *core.RegisterBrowserRelayRequest) (*core.RegisterBrowserRelayResponse, error) {
+	if s.registerBrowserRelay == nil {
+		return nil, errors.New("unexpected register browser relay call")
+	}
 	return s.registerBrowserRelay(ctx, req)
 }
 
 func (s *stubService) UnwrapArtifact(ctx context.Context, req *core.UnwrapArtifactRequest) (*core.UnwrapArtifactResponse, error) {
+	if s.unwrapArtifact == nil {
+		return nil, errors.New("unexpected unwrap artifact call")
+	}
 	return s.unwrapArtifact(ctx, req)
 }


### PR DESCRIPTION
## Summary
- enforce JSON content types and a configurable request body cap on the JSON HTTP API
- add per-endpoint request context timeouts in the HTTP layer and configurable server read/write/idle timeouts
- cover oversized bodies, unsupported content types, timeout behavior, and env parsing in tests

## Testing
- go test ./cmd/asb-api ./internal/api/httpapi
- go test ./...
- git diff --check