### PR TITLE
Add ASB readiness checks and graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ Flags: `-interval` (default 30s), `-limit` (default 100 per pass), `-once` (sing
 | `ASB_POSTGRES_DSN` | Enables Postgres repository |
 | `ASB_REDIS_ADDR` | Enables Redis runtime store |
 | `ASB_REDIS_PASSWORD` | Redis authentication |
+| `ASB_HTTP_MAX_BODY_BYTES` | Maximum JSON request body size |
+| `ASB_HTTP_READ_TIMEOUT` | HTTP server read timeout |
+| `ASB_HTTP_WRITE_TIMEOUT` | HTTP server write timeout |
+| `ASB_HTTP_IDLE_TIMEOUT` | HTTP server idle timeout |
+| `ASB_HTTP_DEFAULT_TIMEOUT` | Default JSON handler timeout |
+| `ASB_HTTP_GRANT_TIMEOUT` | Grant and approval handler timeout |
+| `ASB_HTTP_PROXY_TIMEOUT` | Proxy handler timeout |
+| `ASB_HTTP_READY_TIMEOUT` | Dependency timeout for `/readyz` |
+| `ASB_HTTP_SHUTDOWN_TIMEOUT` | API shutdown drain timeout |
 | `ASB_GITHUB_TOKEN` | Static GitHub token (dev) |
 | `ASB_GITHUB_API_BASE_URL` | GitHub API base URL override |
 | `ASB_GITHUB_APP_ID` | GitHub App ID |
@@ -277,10 +286,11 @@ export ASB_GITHUB_TOKEN="ghp_..."
 make run-api
 ```
 
-### Health check
+### Health checks
 
 ```bash
 curl http://localhost:8080/healthz
+curl http://localhost:8080/readyz
 ```
 
 ## Testing

--- a/cmd/asb-api/config.go
+++ b/cmd/asb-api/config.go
@@ -8,26 +8,30 @@ import (
 )
 
 type serverConfig struct {
-	addr           string
-	maxBodyBytes   int64
-	readTimeout    time.Duration
-	writeTimeout   time.Duration
-	idleTimeout    time.Duration
-	defaultTimeout time.Duration
-	grantTimeout   time.Duration
-	proxyTimeout   time.Duration
+	addr            string
+	maxBodyBytes    int64
+	readTimeout     time.Duration
+	writeTimeout    time.Duration
+	idleTimeout     time.Duration
+	readyTimeout    time.Duration
+	shutdownTimeout time.Duration
+	defaultTimeout  time.Duration
+	grantTimeout    time.Duration
+	proxyTimeout    time.Duration
 }
 
 func loadServerConfig() (serverConfig, error) {
 	cfg := serverConfig{
-		addr:           getenv("ASB_ADDR", ":8080"),
-		maxBodyBytes:   1 << 20,
-		readTimeout:    10 * time.Second,
-		writeTimeout:   30 * time.Second,
-		idleTimeout:    120 * time.Second,
-		defaultTimeout: 10 * time.Second,
-		grantTimeout:   20 * time.Second,
-		proxyTimeout:   30 * time.Second,
+		addr:            getenv("ASB_ADDR", ":8080"),
+		maxBodyBytes:    1 << 20,
+		readTimeout:     10 * time.Second,
+		writeTimeout:    30 * time.Second,
+		idleTimeout:     120 * time.Second,
+		readyTimeout:    2 * time.Second,
+		shutdownTimeout: 30 * time.Second,
+		defaultTimeout:  10 * time.Second,
+		grantTimeout:    20 * time.Second,
+		proxyTimeout:    30 * time.Second,
 	}
 
 	var err error
@@ -41,6 +45,12 @@ func loadServerConfig() (serverConfig, error) {
 		return serverConfig{}, err
 	}
 	if cfg.idleTimeout, err = parsePositiveDurationEnv("ASB_HTTP_IDLE_TIMEOUT", cfg.idleTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.readyTimeout, err = parsePositiveDurationEnv("ASB_HTTP_READY_TIMEOUT", cfg.readyTimeout); err != nil {
+		return serverConfig{}, err
+	}
+	if cfg.shutdownTimeout, err = parsePositiveDurationEnv("ASB_HTTP_SHUTDOWN_TIMEOUT", cfg.shutdownTimeout); err != nil {
 		return serverConfig{}, err
 	}
 	if cfg.defaultTimeout, err = parsePositiveDurationEnv("ASB_HTTP_DEFAULT_TIMEOUT", cfg.defaultTimeout); err != nil {

--- a/cmd/asb-api/config_test.go
+++ b/cmd/asb-api/config_test.go
@@ -11,6 +11,8 @@ func TestLoadServerConfigDefaults(t *testing.T) {
 	t.Setenv("ASB_HTTP_READ_TIMEOUT", "")
 	t.Setenv("ASB_HTTP_WRITE_TIMEOUT", "")
 	t.Setenv("ASB_HTTP_IDLE_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_READY_TIMEOUT", "")
+	t.Setenv("ASB_HTTP_SHUTDOWN_TIMEOUT", "")
 	t.Setenv("ASB_HTTP_DEFAULT_TIMEOUT", "")
 	t.Setenv("ASB_HTTP_GRANT_TIMEOUT", "")
 	t.Setenv("ASB_HTTP_PROXY_TIMEOUT", "")
@@ -28,6 +30,9 @@ func TestLoadServerConfigDefaults(t *testing.T) {
 	if cfg.readTimeout != 10*time.Second || cfg.writeTimeout != 30*time.Second || cfg.idleTimeout != 120*time.Second {
 		t.Fatalf("unexpected server timeouts: %#v", cfg)
 	}
+	if cfg.readyTimeout != 2*time.Second || cfg.shutdownTimeout != 30*time.Second {
+		t.Fatalf("unexpected health/shutdown timeouts: %#v", cfg)
+	}
 }
 
 func TestLoadServerConfigParsesOverrides(t *testing.T) {
@@ -36,6 +41,8 @@ func TestLoadServerConfigParsesOverrides(t *testing.T) {
 	t.Setenv("ASB_HTTP_READ_TIMEOUT", "11s")
 	t.Setenv("ASB_HTTP_WRITE_TIMEOUT", "41s")
 	t.Setenv("ASB_HTTP_IDLE_TIMEOUT", "2m")
+	t.Setenv("ASB_HTTP_READY_TIMEOUT", "3s")
+	t.Setenv("ASB_HTTP_SHUTDOWN_TIMEOUT", "35s")
 	t.Setenv("ASB_HTTP_DEFAULT_TIMEOUT", "9s")
 	t.Setenv("ASB_HTTP_GRANT_TIMEOUT", "29s")
 	t.Setenv("ASB_HTTP_PROXY_TIMEOUT", "45s")
@@ -49,6 +56,9 @@ func TestLoadServerConfigParsesOverrides(t *testing.T) {
 	}
 	if cfg.readTimeout != 11*time.Second || cfg.writeTimeout != 41*time.Second || cfg.idleTimeout != 2*time.Minute {
 		t.Fatalf("unexpected server timeouts: %#v", cfg)
+	}
+	if cfg.readyTimeout != 3*time.Second || cfg.shutdownTimeout != 35*time.Second {
+		t.Fatalf("unexpected health/shutdown timeouts: %#v", cfg)
 	}
 	if cfg.defaultTimeout != 9*time.Second || cfg.grantTimeout != 29*time.Second || cfg.proxyTimeout != 45*time.Second {
 		t.Fatalf("unexpected request timeouts: %#v", cfg)

--- a/cmd/asb-api/health.go
+++ b/cmd/asb-api/health.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/evalops/asb/internal/bootstrap"
+)
+
+type readinessReporter interface {
+	CheckReadiness(ctx context.Context) bootstrap.ReadinessReport
+}
+
+func registerHealthHandlers(mux *http.ServeMux, checker readinessReporter, timeout time.Duration) {
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		report := bootstrap.ReadinessReport{
+			Ready:  true,
+			Checks: map[string]bootstrap.ReadinessCheck{},
+		}
+		if checker != nil {
+			ctx, cancel := context.WithTimeout(r.Context(), timeout)
+			defer cancel()
+			report = checker.CheckReadiness(ctx)
+		}
+
+		status := http.StatusOK
+		if !report.Ready {
+			status = http.StatusServiceUnavailable
+		}
+		writeJSON(w, status, report)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(append(data, '\n'))
+}

--- a/cmd/asb-api/health_test.go
+++ b/cmd/asb-api/health_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evalops/asb/internal/bootstrap"
+)
+
+type fakeReadinessReporter struct {
+	report bootstrap.ReadinessReport
+}
+
+func (f fakeReadinessReporter) CheckReadiness(context.Context) bootstrap.ReadinessReport {
+	return f.report
+}
+
+func TestRegisterHealthHandlersLiveness(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	registerHealthHandlers(mux, nil, time.Second)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if recorder.Body.String() != "ok" {
+		t.Fatalf("body = %q, want %q", recorder.Body.String(), "ok")
+	}
+}
+
+func TestRegisterHealthHandlersReadiness(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	registerHealthHandlers(mux, fakeReadinessReporter{
+		report: bootstrap.ReadinessReport{
+			Ready: true,
+			Checks: map[string]bootstrap.ReadinessCheck{
+				"postgres":            {Status: "ok"},
+				"redis":               {Status: "disabled"},
+				"session_signing_key": {Status: "ok"},
+			},
+		},
+	}, time.Second)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var payload bootstrap.ReadinessReport
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !payload.Ready || payload.Checks["postgres"].Status != "ok" {
+		t.Fatalf("payload = %#v, want ready postgres check", payload)
+	}
+}
+
+func TestRegisterHealthHandlersReadinessFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	registerHealthHandlers(mux, fakeReadinessReporter{
+		report: bootstrap.ReadinessReport{
+			Ready: false,
+			Checks: map[string]bootstrap.ReadinessCheck{
+				"postgres":            {Status: "error", Message: "dial tcp 127.0.0.1:5432: connect: refused"},
+				"redis":               {Status: "ok"},
+				"session_signing_key": {Status: "ok"},
+			},
+		},
+	}, time.Second)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if got := recorder.Body.String(); !containsAll(got, "postgres", "error", "connect: refused") {
+		t.Fatalf("body = %q, want postgres failure details", got)
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/asb-api/main.go
+++ b/cmd/asb-api/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/evalops/asb/internal/api/connectapi"
 	"github.com/evalops/asb/internal/api/httpapi"
@@ -13,14 +16,15 @@ import (
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	svc, cleanup, err := bootstrap.NewService(ctx, logger)
+	runtime, err := bootstrap.NewServiceRuntime(ctx, logger)
 	if err != nil {
 		logger.Error("bootstrap service", "error", err)
 		os.Exit(1)
 	}
-	defer cleanup()
+	defer runtime.Cleanup()
 
 	cfg, err := loadServerConfig()
 	if err != nil {
@@ -30,16 +34,13 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/", httpapi.NewServer(
-		svc,
+		runtime.Service,
 		httpapi.WithMaxBodyBytes(cfg.maxBodyBytes),
 		httpapi.WithRequestTimeouts(cfg.defaultTimeout, cfg.grantTimeout, cfg.proxyTimeout),
 	))
-	connectPath, connectHandler := connectapi.NewHandler(svc)
+	connectPath, connectHandler := connectapi.NewHandler(runtime.Service)
 	mux.Handle(connectPath, connectHandler)
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
+	registerHealthHandlers(mux, runtime.Health, cfg.readyTimeout)
 
 	server := &http.Server{
 		Addr:         cfg.addr,
@@ -55,12 +56,38 @@ func main() {
 		"read_timeout", cfg.readTimeout,
 		"write_timeout", cfg.writeTimeout,
 		"idle_timeout", cfg.idleTimeout,
+		"ready_timeout", cfg.readyTimeout,
+		"shutdown_timeout", cfg.shutdownTimeout,
 		"default_timeout", cfg.defaultTimeout,
 		"grant_timeout", cfg.grantTimeout,
 		"proxy_timeout", cfg.proxyTimeout,
 	)
-	if err := server.ListenAndServe(); err != nil {
-		logger.Error("server exited", "error", err)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serverErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server exited", "error", err)
+			os.Exit(1)
+		}
+		return
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.shutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Error("shutdown server", "error", err)
+		os.Exit(1)
+	}
+
+	if err := <-serverErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("server exited after shutdown", "error", err)
 		os.Exit(1)
 	}
 }

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -42,6 +42,30 @@ type serviceOptions struct {
 	requireVerifier bool
 }
 
+type readinessProbe func(context.Context) error
+
+type ServiceRuntime struct {
+	Service *app.Service
+	Cleanup func()
+	Health  *HealthChecker
+}
+
+type HealthChecker struct {
+	postgresProbe      readinessProbe
+	redisProbe         readinessProbe
+	sessionTokensReady bool
+}
+
+type ReadinessCheck struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+type ReadinessReport struct {
+	Ready  bool                      `json:"ready"`
+	Checks map[string]ReadinessCheck `json:"checks"`
+}
+
 func WithVerificationOptional() ServiceOption {
 	return func(options *serviceOptions) {
 		options.requireVerifier = false
@@ -49,6 +73,14 @@ func WithVerificationOptional() ServiceOption {
 }
 
 func NewService(ctx context.Context, logger *slog.Logger, options ...ServiceOption) (*app.Service, func(), error) {
+	runtime, err := NewServiceRuntime(ctx, logger, options...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return runtime.Service, runtime.Cleanup, nil
+}
+
+func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...ServiceOption) (*ServiceRuntime, error) {
 	config := serviceOptions{requireVerifier: true}
 	for _, option := range options {
 		option(&config)
@@ -56,20 +88,20 @@ func NewService(ctx context.Context, logger *slog.Logger, options ...ServiceOpti
 
 	verifier, err := newVerifier(config.requireVerifier)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	sessionTokens, err := newSessionTokenManager()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	repository, cleanupRepository, err := newRepository(ctx)
+	repository, cleanupRepository, postgresProbe, err := newRepository(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	runtimeStore, cleanupRuntime, err := newRuntimeStore(ctx)
+	runtimeStore, cleanupRuntime, redisProbe, err := newRuntimeStore(ctx)
 	if err != nil {
 		cleanupRepository()
-		return nil, nil, err
+		return nil, err
 	}
 
 	auditSink := auditmemory.NewSink()
@@ -83,7 +115,7 @@ func NewService(ctx context.Context, logger *slog.Logger, options ...ServiceOpti
 	if err != nil {
 		cleanupRuntime()
 		cleanupRepository()
-		return nil, nil, err
+		return nil, err
 	}
 
 	tenantID := getenv("ASB_DEV_TENANT_ID", "t_dev")
@@ -188,7 +220,7 @@ func NewService(ctx context.Context, logger *slog.Logger, options ...ServiceOpti
 	if err != nil {
 		cleanupRuntime()
 		cleanupRepository()
-		return nil, nil, err
+		return nil, err
 	}
 
 	svc, err := app.NewService(app.Config{
@@ -211,13 +243,68 @@ func NewService(ctx context.Context, logger *slog.Logger, options ...ServiceOpti
 	if err != nil {
 		cleanupRuntime()
 		cleanupRepository()
-		return nil, nil, err
+		return nil, err
 	}
 
-	return svc, func() {
-		cleanupRuntime()
-		cleanupRepository()
+	return &ServiceRuntime{
+		Service: svc,
+		Cleanup: func() {
+			cleanupRuntime()
+			cleanupRepository()
+		},
+		Health: &HealthChecker{
+			postgresProbe:      postgresProbe,
+			redisProbe:         redisProbe,
+			sessionTokensReady: sessionTokens != nil,
+		},
 	}, nil
+}
+
+func (h *HealthChecker) CheckReadiness(ctx context.Context) ReadinessReport {
+	report := ReadinessReport{
+		Ready: true,
+		Checks: map[string]ReadinessCheck{
+			"session_signing_key": readyCheck(h.sessionTokensReady),
+			"postgres":            disabledCheck(),
+			"redis":               disabledCheck(),
+		},
+	}
+
+	if h.postgresProbe != nil {
+		report.Checks["postgres"] = runProbe(ctx, h.postgresProbe)
+		if report.Checks["postgres"].Status != "ok" {
+			report.Ready = false
+		}
+	}
+	if h.redisProbe != nil {
+		report.Checks["redis"] = runProbe(ctx, h.redisProbe)
+		if report.Checks["redis"].Status != "ok" {
+			report.Ready = false
+		}
+	}
+	if report.Checks["session_signing_key"].Status != "ok" {
+		report.Ready = false
+	}
+
+	return report
+}
+
+func readyCheck(ok bool) ReadinessCheck {
+	if ok {
+		return ReadinessCheck{Status: "ok"}
+	}
+	return ReadinessCheck{Status: "error", Message: "session token manager is not configured"}
+}
+
+func disabledCheck() ReadinessCheck {
+	return ReadinessCheck{Status: "disabled"}
+}
+
+func runProbe(ctx context.Context, probe readinessProbe) ReadinessCheck {
+	if err := probe(ctx); err != nil {
+		return ReadinessCheck{Status: "error", Message: err.Error()}
+	}
+	return ReadinessCheck{Status: "ok"}
 }
 
 func newVerifier(require bool) (core.AttestationVerifier, error) {
@@ -320,18 +407,18 @@ func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
 	}), nil
 }
 
-func newRepository(ctx context.Context) (core.Repository, func(), error) {
+func newRepository(ctx context.Context) (core.Repository, func(), readinessProbe, error) {
 	if dsn := os.Getenv("ASB_POSTGRES_DSN"); dsn != "" {
 		pool, err := pgxpool.New(ctx, dsn)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return postgresstore.NewRepository(pool), pool.Close, nil
+		return postgresstore.NewRepository(pool), pool.Close, pool.Ping, nil
 	}
-	return memstore.NewRepository(), func() {}, nil
+	return memstore.NewRepository(), func() {}, nil, nil
 }
 
-func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), error) {
+func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), readinessProbe, error) {
 	if addr := os.Getenv("ASB_REDIS_ADDR"); addr != "" {
 		client := goredis.NewClient(&goredis.Options{
 			Addr:     addr,
@@ -339,11 +426,13 @@ func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), error) {
 			DB:       0,
 		})
 		if err := client.Ping(ctx).Err(); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return redisstore.NewRuntimeStore(client), func() { _ = client.Close() }, nil
+		return redisstore.NewRuntimeStore(client), func() { _ = client.Close() }, func(ctx context.Context) error {
+			return client.Ping(ctx).Err()
+		}, nil
 	}
-	return memstore.NewRuntimeStore(), func() {}, nil
+	return memstore.NewRuntimeStore(), func() {}, nil, nil
 }
 
 func loadPublicKey(path string) (any, error) {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -63,7 +63,10 @@ func (r *Runner) RunOnce(ctx context.Context) (*app.CleanupStats, error) {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-	if _, err := r.RunOnce(ctx); err != nil {
+	if ctx.Err() != nil {
+		return nil
+	}
+	if _, err := r.RunOnce(context.WithoutCancel(ctx)); err != nil {
 		return err
 	}
 
@@ -75,7 +78,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if _, err := r.RunOnce(ctx); err != nil {
+			if _, err := r.RunOnce(context.WithoutCancel(ctx)); err != nil {
 				return err
 			}
 		}

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,18 +60,76 @@ func TestRunner_RunPropagatesErrors(t *testing.T) {
 	}
 }
 
-type fakeCleanupService struct {
-	stats *app.CleanupStats
-	err   error
-	calls int
+func TestRunner_RunDrainsCurrentPassBeforeExit(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	service := &fakeCleanupService{
+		stats: &app.CleanupStats{},
+		runCleanupOnce: func(ctx context.Context, limit int) (*app.CleanupStats, error) {
+			close(started)
+			<-release
+			return &app.CleanupStats{}, nil
+		},
+	}
+	runner := worker.NewRunner(worker.Config{
+		Service:  service,
+		Limit:    50,
+		Interval: 5 * time.Millisecond,
+		Logger:   slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runner.Run(ctx)
+	}()
+
+	<-started
+	cancel()
+	close(release)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not exit after draining current pass")
+	}
+
+	service.mu.Lock()
+	calls := service.calls
+	service.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("service calls = %d, want 1", calls)
+	}
 }
 
-func (f *fakeCleanupService) RunCleanupOnce(context.Context, int) (*app.CleanupStats, error) {
+type fakeCleanupService struct {
+	stats          *app.CleanupStats
+	err            error
+	runCleanupOnce func(context.Context, int) (*app.CleanupStats, error)
+	calls          int
+	mu             sync.Mutex
+}
+
+func (f *fakeCleanupService) RunCleanupOnce(ctx context.Context, limit int) (*app.CleanupStats, error) {
+	f.mu.Lock()
 	f.calls++
-	if f.err != nil {
-		return nil, f.err
+	runCleanupOnce := f.runCleanupOnce
+	stats := f.stats
+	err := f.err
+	f.mu.Unlock()
+
+	if runCleanupOnce != nil {
+		return runCleanupOnce(ctx, limit)
 	}
-	return f.stats, nil
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
 }
 
 type testWriter struct{ t *testing.T }


### PR DESCRIPTION
## Summary
- add `/readyz` dependency checks for Postgres, Redis, and session-signing readiness while keeping `/healthz` as liveness
- expose additive bootstrap runtime health probes so the API process can report real readiness without changing the service layer API
- add graceful API shutdown and worker drain-on-signal behavior, plus timeout/config docs and tests

## Validation
- `go test ./cmd/asb-api ./internal/bootstrap ./internal/worker`
- `go test ./...`
- `git diff --check`