### PR TITLE
Integrate ASB approvals with notifications service

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ASB currently supports:
 - GitHub proxy access through allowlisted operations, including GitHub App installation-token exchange
 - Vault-backed dynamic Postgres credential brokering delivered as wrapped artifacts
 - browser relay registration with single-use unwrap responses and selector-bound fill data
+- shared notifications-service delivery for pending approval events
 - JSON/HTTP and ConnectRPC transports
 - in-memory, Postgres, and Redis-backed storage and runtime components
 - migration and cleanup worker binaries
@@ -67,7 +68,7 @@ ASB currently supports:
 
 ### Intentionally simplified in v1
 
-- no full production approval callback transport yet (approvals work, but notification is in-process only)
+- no full production approval callback transport yet (pending approvals can be emitted through the shared notifications service, but approver routing is still runtime-configured)
 - no KMS-backed artifact encryption yet (artifacts are stored, but not envelope-encrypted at rest)
 - no frontend admin UI or browser extension package in this repo yet
 - minted-token delivery is modeled in the domain but not enabled in runtime wiring
@@ -263,6 +264,12 @@ Flags: `-interval` (default 30s), `-limit` (default 100 per pass), `-once` (sing
 | `ASB_BROWSER_PASSWORD` | Browser credential password (demo) |
 | `ASB_BROWSER_SELECTOR_USERNAME` | CSS selector for username field (demo) |
 | `ASB_BROWSER_SELECTOR_PASSWORD` | CSS selector for password field (demo) |
+| `ASB_NOTIFICATIONS_BASE_URL` | Shared notifications service base URL for pending approval delivery |
+| `ASB_NOTIFICATIONS_RECIPIENT_ID` | Recipient or queue ID for approval notifications |
+| `ASB_NOTIFICATIONS_CHANNEL` | Delivery channel for approval notifications (`slack`, `email`, `webhook`, `in_app`) |
+| `ASB_NOTIFICATIONS_WORKSPACE_ID` | Workspace override for approval notifications (defaults to approval tenant ID) |
+| `ASB_NOTIFICATIONS_BEARER_TOKEN` | Optional bearer token forwarded to the notifications service |
+| `ASB_PUBLIC_BASE_URL` | Optional public ASB base URL used to embed approve/deny endpoints in notification metadata |
 
 ## Local development
 
@@ -292,6 +299,10 @@ make run-api
 curl http://localhost:8080/healthz
 curl http://localhost:8080/readyz
 ```
+
+### Shared approval notifications
+
+If `ASB_NOTIFICATIONS_BASE_URL`, `ASB_NOTIFICATIONS_RECIPIENT_ID`, and `ASB_NOTIFICATIONS_CHANNEL` are set, pending approvals are sent through the shared `notifications` service with structured metadata for `approval_id`, `grant_id`, `tenant_id`, `tool`, `capability`, `resource_ref`, and expiration details. When `ASB_PUBLIC_BASE_URL` is set, ASB also includes approve/deny endpoint hints in that metadata for downstream tooling.
 
 ## Testing
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	connectrpc.com/connect v1.19.1
 	github.com/alicebob/miniredis/v2 v2.37.0
+	github.com/evalops/proto v0.0.0-20260414000509-37b2bf5d6244
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/pashagolub/pgxmock/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/evalops/proto v0.0.0-20260414000509-37b2bf5d6244 h1:MjoKPIxG/OisQLDqLvbvpleCAkPgr2InTrK4Q0D9F1o=
+github.com/evalops/proto v0.0.0-20260414000509-37b2bf5d6244/go.mod h1:EXB8IcqMaV58Tt0w2GaQia3YOwzrEvnIWFZetHX+IxE=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/approval/notifications/notifier.go
+++ b/internal/approval/notifications/notifier.go
@@ -1,0 +1,188 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	connect "connectrpc.com/connect"
+	"github.com/evalops/asb/internal/core"
+	notificationsv1 "github.com/evalops/proto/gen/go/notifications/v1"
+	"github.com/evalops/proto/gen/go/notifications/v1/notificationsv1connect"
+)
+
+type Config struct {
+	BaseURL       string
+	BearerToken   string
+	WorkspaceID   string
+	RecipientID   string
+	Channel       notificationsv1.DeliveryChannel
+	Priority      notificationsv1.Priority
+	PublicBaseURL string
+	Client        *http.Client
+}
+
+type notificationSender interface {
+	Send(context.Context, *connect.Request[notificationsv1.SendRequest]) (*connect.Response[notificationsv1.SendResponse], error)
+}
+
+type Notifier struct {
+	client        notificationSender
+	bearerToken   string
+	workspaceID   string
+	recipientID   string
+	channel       notificationsv1.DeliveryChannel
+	priority      notificationsv1.Priority
+	publicBaseURL string
+}
+
+func NewNotifier(cfg Config) (*Notifier, error) {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, fmt.Errorf("notifications base url is required")
+	}
+	if strings.TrimSpace(cfg.RecipientID) == "" {
+		return nil, fmt.Errorf("notifications recipient id is required")
+	}
+	if cfg.Channel == notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_UNSPECIFIED {
+		return nil, fmt.Errorf("notifications channel is required")
+	}
+	if cfg.Priority == notificationsv1.Priority_PRIORITY_UNSPECIFIED {
+		cfg.Priority = notificationsv1.Priority_PRIORITY_HIGH
+	}
+	if cfg.Client == nil {
+		cfg.Client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	return &Notifier{
+		client:        notificationsv1connect.NewNotificationServiceClient(cfg.Client, strings.TrimRight(cfg.BaseURL, "/")),
+		bearerToken:   strings.TrimSpace(cfg.BearerToken),
+		workspaceID:   strings.TrimSpace(cfg.WorkspaceID),
+		recipientID:   strings.TrimSpace(cfg.RecipientID),
+		channel:       cfg.Channel,
+		priority:      cfg.Priority,
+		publicBaseURL: strings.TrimRight(strings.TrimSpace(cfg.PublicBaseURL), "/"),
+	}, nil
+}
+
+func NewNotifierWithClient(client notificationSender, cfg Config) (*Notifier, error) {
+	if client == nil {
+		return nil, fmt.Errorf("notifications client is required")
+	}
+	if strings.TrimSpace(cfg.RecipientID) == "" {
+		return nil, fmt.Errorf("notifications recipient id is required")
+	}
+	if cfg.Channel == notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_UNSPECIFIED {
+		return nil, fmt.Errorf("notifications channel is required")
+	}
+	if cfg.Priority == notificationsv1.Priority_PRIORITY_UNSPECIFIED {
+		cfg.Priority = notificationsv1.Priority_PRIORITY_HIGH
+	}
+
+	return &Notifier{
+		client:        client,
+		bearerToken:   strings.TrimSpace(cfg.BearerToken),
+		workspaceID:   strings.TrimSpace(cfg.WorkspaceID),
+		recipientID:   strings.TrimSpace(cfg.RecipientID),
+		channel:       cfg.Channel,
+		priority:      cfg.Priority,
+		publicBaseURL: strings.TrimRight(strings.TrimSpace(cfg.PublicBaseURL), "/"),
+	}, nil
+}
+
+func ParseChannel(raw string) (notificationsv1.DeliveryChannel, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "slack":
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_SLACK, nil
+	case "email":
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_EMAIL, nil
+	case "webhook":
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_WEBHOOK, nil
+	case "in_app", "in-app", "inapp":
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_IN_APP, nil
+	case "":
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_UNSPECIFIED, fmt.Errorf("notifications channel is required")
+	default:
+		return notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_UNSPECIFIED, fmt.Errorf("unsupported notifications channel %q", raw)
+	}
+}
+
+func (n *Notifier) NotifyPending(ctx context.Context, _ *core.ApprovalCallbackConfig, approval *core.Approval, grant *core.Grant) error {
+	if approval == nil {
+		return fmt.Errorf("approval is required")
+	}
+	if grant == nil {
+		return fmt.Errorf("grant is required")
+	}
+
+	workspaceID := n.workspaceID
+	if workspaceID == "" {
+		workspaceID = approval.TenantID
+	}
+
+	metadataJSON, err := json.Marshal(n.buildMetadata(approval, grant, workspaceID))
+	if err != nil {
+		return fmt.Errorf("marshal approval notification metadata: %w", err)
+	}
+
+	req := connect.NewRequest(&notificationsv1.SendRequest{
+		WorkspaceId:  workspaceID,
+		RecipientId:  n.recipientID,
+		Channel:      n.channel,
+		Priority:     n.priority,
+		Subject:      buildSubject(grant),
+		Body:         buildBody(approval, grant),
+		MetadataJson: string(metadataJSON),
+	})
+	if n.bearerToken != "" {
+		req.Header().Set("Authorization", "Bearer "+n.bearerToken)
+	}
+
+	if _, err := n.client.Send(ctx, req); err != nil {
+		return fmt.Errorf("send approval notification %q: %w", approval.ID, err)
+	}
+	return nil
+}
+
+func (n *Notifier) buildMetadata(approval *core.Approval, grant *core.Grant, workspaceID string) map[string]any {
+	metadata := map[string]any{
+		"approval_id":  approval.ID,
+		"grant_id":     grant.ID,
+		"tenant_id":    approval.TenantID,
+		"workspace_id": workspaceID,
+		"requested_by": approval.RequestedBy,
+		"tool":         grant.Tool,
+		"capability":   grant.Capability,
+		"resource_ref": grant.ResourceRef,
+		"reason":       approval.Reason,
+		"expires_at":   approval.ExpiresAt.UTC().Format(time.RFC3339),
+	}
+	if n.publicBaseURL != "" {
+		metadata["approve_endpoint"] = n.publicBaseURL + "/v1/approvals/" + approval.ID + ":approve"
+		metadata["deny_endpoint"] = n.publicBaseURL + "/v1/approvals/" + approval.ID + ":deny"
+	}
+	return metadata
+}
+
+func buildSubject(grant *core.Grant) string {
+	return fmt.Sprintf("Approval required: %s on %s", grant.Capability, grant.ResourceRef)
+}
+
+func buildBody(approval *core.Approval, grant *core.Grant) string {
+	lines := []string{
+		fmt.Sprintf("Approval is required for grant %s.", grant.ID),
+		fmt.Sprintf("Requested by: %s", approval.RequestedBy),
+		fmt.Sprintf("Tool: %s", grant.Tool),
+		fmt.Sprintf("Capability: %s", grant.Capability),
+		fmt.Sprintf("Resource: %s", grant.ResourceRef),
+		fmt.Sprintf("Expires at: %s", approval.ExpiresAt.UTC().Format(time.RFC3339)),
+	}
+	if approval.Reason != "" {
+		lines = append(lines, fmt.Sprintf("Reason: %s", approval.Reason))
+	}
+	return strings.Join(lines, "\n")
+}
+
+var _ core.ApprovalNotifier = (*Notifier)(nil)

--- a/internal/approval/notifications/notifier_test.go
+++ b/internal/approval/notifications/notifier_test.go
@@ -1,0 +1,154 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	connect "connectrpc.com/connect"
+	"github.com/evalops/asb/internal/core"
+	notificationsv1 "github.com/evalops/proto/gen/go/notifications/v1"
+)
+
+type fakeNotificationSender struct {
+	send func(context.Context, *connect.Request[notificationsv1.SendRequest]) (*connect.Response[notificationsv1.SendResponse], error)
+}
+
+func (f fakeNotificationSender) Send(ctx context.Context, req *connect.Request[notificationsv1.SendRequest]) (*connect.Response[notificationsv1.SendResponse], error) {
+	return f.send(ctx, req)
+}
+
+func TestNotifierNotifyPending(t *testing.T) {
+	t.Parallel()
+
+	var sent *notificationsv1.SendRequest
+	var authHeader string
+	notifier, err := NewNotifierWithClient(fakeNotificationSender{
+		send: func(_ context.Context, req *connect.Request[notificationsv1.SendRequest]) (*connect.Response[notificationsv1.SendResponse], error) {
+			sent = req.Msg
+			authHeader = req.Header().Get("Authorization")
+			return connect.NewResponse(&notificationsv1.SendResponse{
+				Notification: &notificationsv1.Notification{Id: "ntf_123"},
+			}), nil
+		},
+	}, Config{
+		BearerToken:   "secret-token",
+		RecipientID:   "approval-queue",
+		Channel:       notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_SLACK,
+		Priority:      notificationsv1.Priority_PRIORITY_URGENT,
+		PublicBaseURL: "https://asb.internal",
+	})
+	if err != nil {
+		t.Fatalf("NewNotifierWithClient() error = %v", err)
+	}
+
+	approval := &core.Approval{
+		ID:          "ap_123",
+		TenantID:    "t_acme",
+		GrantID:     "gr_123",
+		RequestedBy: "agent_browser",
+		Reason:      "log into vendor admin",
+		ExpiresAt:   time.Date(2026, 4, 14, 1, 0, 0, 0, time.UTC),
+	}
+	grant := &core.Grant{
+		ID:          "gr_123",
+		Tool:        "browser",
+		Capability:  "browser.login",
+		ResourceRef: "browser_origin:https://admin.vendor.example",
+	}
+
+	if err := notifier.NotifyPending(context.Background(), nil, approval, grant); err != nil {
+		t.Fatalf("NotifyPending() error = %v", err)
+	}
+	if sent == nil {
+		t.Fatal("Send() was not called")
+	}
+	if sent.GetWorkspaceId() != "t_acme" {
+		t.Fatalf("workspace_id = %q, want tenant id fallback", sent.GetWorkspaceId())
+	}
+	if sent.GetRecipientId() != "approval-queue" {
+		t.Fatalf("recipient_id = %q, want approval-queue", sent.GetRecipientId())
+	}
+	if sent.GetChannel() != notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_SLACK {
+		t.Fatalf("channel = %s, want slack", sent.GetChannel())
+	}
+	if sent.GetPriority() != notificationsv1.Priority_PRIORITY_URGENT {
+		t.Fatalf("priority = %s, want urgent", sent.GetPriority())
+	}
+	if authHeader != "Bearer secret-token" {
+		t.Fatalf("authorization = %q, want bearer token", authHeader)
+	}
+	if sent.GetSubject() == "" || sent.GetBody() == "" || sent.GetMetadataJson() == "" {
+		t.Fatalf("send request = %#v, want subject/body/metadata", sent)
+	}
+	if !containsAll(sent.GetMetadataJson(), "approve_endpoint", "deny_endpoint", "browser.login") {
+		t.Fatalf("metadata_json = %q, want approval endpoints and capability", sent.GetMetadataJson())
+	}
+}
+
+func TestNotifierNotifyPendingPropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	notifier, err := NewNotifierWithClient(fakeNotificationSender{
+		send: func(_ context.Context, req *connect.Request[notificationsv1.SendRequest]) (*connect.Response[notificationsv1.SendResponse], error) {
+			return nil, errors.New("boom")
+		},
+	}, Config{
+		RecipientID: "approval-queue",
+		Channel:     notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_EMAIL,
+	})
+	if err != nil {
+		t.Fatalf("NewNotifierWithClient() error = %v", err)
+	}
+
+	err = notifier.NotifyPending(context.Background(), nil, &core.Approval{
+		ID:          "ap_123",
+		TenantID:    "t_acme",
+		RequestedBy: "agent_browser",
+		ExpiresAt:   time.Now().UTC(),
+	}, &core.Grant{
+		ID:          "gr_123",
+		Tool:        "browser",
+		Capability:  "browser.login",
+		ResourceRef: "browser_origin:https://admin.vendor.example",
+	})
+	if err == nil || !containsAll(err.Error(), "send approval notification", "boom") {
+		t.Fatalf("NotifyPending() error = %v, want wrapped send error", err)
+	}
+}
+
+func TestParseChannel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]notificationsv1.DeliveryChannel{
+		"slack":   notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_SLACK,
+		"email":   notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_EMAIL,
+		"webhook": notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_WEBHOOK,
+		"in_app":  notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_IN_APP,
+	}
+
+	for input, want := range cases {
+		got, err := ParseChannel(input)
+		if err != nil {
+			t.Fatalf("ParseChannel(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("ParseChannel(%q) = %s, want %s", input, got, want)
+		}
+	}
+
+	if _, err := ParseChannel("sms"); err == nil {
+		t.Fatal("ParseChannel(sms) error = nil, want non-nil")
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -12,9 +12,11 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/evalops/asb/internal/app"
+	approvalnotifications "github.com/evalops/asb/internal/approval/notifications"
 	auditmemory "github.com/evalops/asb/internal/audit/memory"
 	"github.com/evalops/asb/internal/authn/delegationjwt"
 	"github.com/evalops/asb/internal/authn/k8s"
@@ -112,6 +114,12 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 	}
 
 	githubProxy, err := newGitHubProxyExecutor()
+	if err != nil {
+		cleanupRuntime()
+		cleanupRepository()
+		return nil, err
+	}
+	approvalNotifier, err := newApprovalNotifier()
 	if err != nil {
 		cleanupRuntime()
 		cleanupRepository()
@@ -236,9 +244,10 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 			core.DeliveryModeProxy:         proxydelivery.NewAdapter(),
 			core.DeliveryModeWrappedSecret: wrappeddelivery.NewAdapter(),
 		},
-		Audit:       auditSink,
-		Runtime:     runtimeStore,
-		GitHubProxy: githubProxy,
+		Audit:            auditSink,
+		Runtime:          runtimeStore,
+		ApprovalNotifier: approvalNotifier,
+		GitHubProxy:      githubProxy,
 	})
 	if err != nil {
 		cleanupRuntime()
@@ -405,6 +414,36 @@ func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
 		BaseURL:     getenv("ASB_GITHUB_API_BASE_URL", "https://api.github.com"),
 		TokenSource: tokenSource,
 	}), nil
+}
+
+func newApprovalNotifier() (core.ApprovalNotifier, error) {
+	baseURL := strings.TrimSpace(os.Getenv("ASB_NOTIFICATIONS_BASE_URL"))
+	recipientID := strings.TrimSpace(os.Getenv("ASB_NOTIFICATIONS_RECIPIENT_ID"))
+	channelRaw := strings.TrimSpace(os.Getenv("ASB_NOTIFICATIONS_CHANNEL"))
+	workspaceID := strings.TrimSpace(os.Getenv("ASB_NOTIFICATIONS_WORKSPACE_ID"))
+	bearerToken := strings.TrimSpace(os.Getenv("ASB_NOTIFICATIONS_BEARER_TOKEN"))
+	publicBaseURL := strings.TrimSpace(os.Getenv("ASB_PUBLIC_BASE_URL"))
+
+	if baseURL == "" {
+		if recipientID != "" || channelRaw != "" || workspaceID != "" || bearerToken != "" || publicBaseURL != "" {
+			return nil, fmt.Errorf("ASB_NOTIFICATIONS_BASE_URL is required when approval notifications are configured")
+		}
+		return nil, nil
+	}
+
+	channel, err := approvalnotifications.ParseChannel(channelRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse ASB_NOTIFICATIONS_CHANNEL: %w", err)
+	}
+
+	return approvalnotifications.NewNotifier(approvalnotifications.Config{
+		BaseURL:       baseURL,
+		BearerToken:   bearerToken,
+		WorkspaceID:   workspaceID,
+		RecipientID:   recipientID,
+		Channel:       channel,
+		PublicBaseURL: publicBaseURL,
+	})
 }
 
 func newRepository(ctx context.Context) (core.Repository, func(), readinessProbe, error) {

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -1,0 +1,68 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewApprovalNotifierDisabledByDefault(t *testing.T) {
+	t.Setenv("ASB_NOTIFICATIONS_BASE_URL", "")
+	t.Setenv("ASB_NOTIFICATIONS_RECIPIENT_ID", "")
+	t.Setenv("ASB_NOTIFICATIONS_CHANNEL", "")
+	t.Setenv("ASB_NOTIFICATIONS_WORKSPACE_ID", "")
+	t.Setenv("ASB_NOTIFICATIONS_BEARER_TOKEN", "")
+	t.Setenv("ASB_PUBLIC_BASE_URL", "")
+
+	notifier, err := newApprovalNotifier()
+	if err != nil {
+		t.Fatalf("newApprovalNotifier() error = %v", err)
+	}
+	if notifier != nil {
+		t.Fatalf("newApprovalNotifier() = %#v, want nil", notifier)
+	}
+}
+
+func TestNewApprovalNotifierRequiresBaseURLWhenConfigured(t *testing.T) {
+	t.Setenv("ASB_NOTIFICATIONS_BASE_URL", "")
+	t.Setenv("ASB_NOTIFICATIONS_RECIPIENT_ID", "approval-queue")
+	t.Setenv("ASB_NOTIFICATIONS_CHANNEL", "slack")
+
+	notifier, err := newApprovalNotifier()
+	if err == nil || !strings.Contains(err.Error(), "ASB_NOTIFICATIONS_BASE_URL") {
+		t.Fatalf("newApprovalNotifier() error = %v, want base url error", err)
+	}
+	if notifier != nil {
+		t.Fatalf("newApprovalNotifier() = %#v, want nil", notifier)
+	}
+}
+
+func TestNewApprovalNotifierRequiresValidChannel(t *testing.T) {
+	t.Setenv("ASB_NOTIFICATIONS_BASE_URL", "http://notifications:8080")
+	t.Setenv("ASB_NOTIFICATIONS_RECIPIENT_ID", "approval-queue")
+	t.Setenv("ASB_NOTIFICATIONS_CHANNEL", "sms")
+
+	notifier, err := newApprovalNotifier()
+	if err == nil || !strings.Contains(err.Error(), "ASB_NOTIFICATIONS_CHANNEL") {
+		t.Fatalf("newApprovalNotifier() error = %v, want channel error", err)
+	}
+	if notifier != nil {
+		t.Fatalf("newApprovalNotifier() = %#v, want nil", notifier)
+	}
+}
+
+func TestNewApprovalNotifierConfigured(t *testing.T) {
+	t.Setenv("ASB_NOTIFICATIONS_BASE_URL", "http://notifications:8080")
+	t.Setenv("ASB_NOTIFICATIONS_RECIPIENT_ID", "approval-queue")
+	t.Setenv("ASB_NOTIFICATIONS_CHANNEL", "slack")
+	t.Setenv("ASB_NOTIFICATIONS_WORKSPACE_ID", "ws_control")
+	t.Setenv("ASB_NOTIFICATIONS_BEARER_TOKEN", "secret-token")
+	t.Setenv("ASB_PUBLIC_BASE_URL", "https://asb.example.com")
+
+	notifier, err := newApprovalNotifier()
+	if err != nil {
+		t.Fatalf("newApprovalNotifier() error = %v", err)
+	}
+	if notifier == nil {
+		t.Fatal("newApprovalNotifier() = nil, want configured notifier")
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared notifications-service notifier for pending ASB approvals
- wire the notifier through bootstrap with explicit env-based configuration and validation
- document the new approval notification envs and add bootstrap/notifier tests

## Validation
- go test ./internal/approval/notifications ./internal/bootstrap ./internal/app
- go test ./...
- git diff --check