### PR TITLE
Address recent ASB review findings

### DIFF
--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -49,6 +49,7 @@ const (
 )
 
 var errUnsupportedContentType = errors.New("content-type must be application/json")
+var errSingleJSONObject = errors.New("request body must contain a single JSON object")
 
 func NewServer(service Service, options ...Option) *Server {
 	server := &Server{
@@ -107,23 +108,23 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/sessions":
-		s.handleCreateSession(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleCreateSession)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/grants":
-		s.handleRequestGrant(w, s.withTimeout(r, s.timeouts.grantTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.grantTimeout, s.handleRequestGrant)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/approvals/") && strings.HasSuffix(r.URL.Path, ":approve"):
-		s.handleApproveGrant(w, s.withTimeout(r, s.timeouts.grantTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.grantTimeout, s.handleApproveGrant)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/approvals/") && strings.HasSuffix(r.URL.Path, ":deny"):
-		s.handleDenyGrant(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleDenyGrant)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/grants/") && strings.HasSuffix(r.URL.Path, ":revoke"):
-		s.handleRevokeGrant(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleRevokeGrant)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/sessions/") && strings.HasSuffix(r.URL.Path, ":revoke"):
-		s.handleRevokeSession(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleRevokeSession)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/proxy/github/rest":
-		s.handleExecuteGitHubProxy(w, s.withTimeout(r, s.timeouts.proxyTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.proxyTimeout, s.handleExecuteGitHubProxy)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/browser/relay-sessions":
-		s.handleRegisterBrowserRelay(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleRegisterBrowserRelay)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/artifacts/") && strings.HasSuffix(r.URL.Path, ":unwrap"):
-		s.handleUnwrapArtifact(w, s.withTimeout(r, s.timeouts.defaultTimeout))
+		s.serveWithTimeout(w, r, s.timeouts.defaultTimeout, s.handleUnwrapArtifact)
 	default:
 		http.NotFound(w, r)
 	}
@@ -368,7 +369,7 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusUnsupportedMediaType
 	case errors.As(err, &maxBytesErr):
 		status = http.StatusRequestEntityTooLarge
-	case errors.As(err, &syntaxErr), errors.As(err, &typeErr), errors.Is(err, io.EOF):
+	case errors.As(err, &syntaxErr), errors.As(err, &typeErr), errors.Is(err, io.EOF), errors.Is(err, errSingleJSONObject):
 		status = http.StatusBadRequest
 	case errors.Is(err, core.ErrInvalidRequest):
 		status = http.StatusBadRequest
@@ -382,17 +383,21 @@ func writeError(w http.ResponseWriter, err error) {
 	writeJSON(w, status, map[string]string{"error": err.Error()})
 }
 
-func (s *Server) withTimeout(r *http.Request, timeout time.Duration) *http.Request {
+func (s *Server) serveWithTimeout(w http.ResponseWriter, r *http.Request, timeout time.Duration, handler func(http.ResponseWriter, *http.Request)) {
+	r, cancel := s.withTimeout(r, timeout)
+	defer cancel()
+	handler(w, r)
+}
+
+func (s *Server) withTimeout(r *http.Request, timeout time.Duration) (*http.Request, context.CancelFunc) {
 	if timeout <= 0 {
-		return r
+		return r, func() {}
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), timeout)
-	return r.Clone(context.WithValue(ctx, requestCancelKey{}, cancel))
+	return r.Clone(ctx), cancel
 }
 
 func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, out any) error {
-	defer s.finishRequest(r)
-
 	if err := requireJSONContentType(r); err != nil {
 		return err
 	}
@@ -405,19 +410,13 @@ func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, out any) err
 	if err := decoder.Decode(out); err != nil {
 		return err
 	}
-	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
-		return errors.New("request body must contain a single JSON object")
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return errSingleJSONObject
+	} else if !errors.Is(err, io.EOF) {
+		return errSingleJSONObject
 	}
 	return nil
-}
-
-type requestCancelKey struct{}
-
-func (s *Server) finishRequest(r *http.Request) {
-	cancel, _ := r.Context().Value(requestCancelKey{}).(context.CancelFunc)
-	if cancel != nil {
-		cancel()
-	}
 }
 
 func requireJSONContentType(r *http.Request) error {

--- a/internal/api/httpapi/server_test.go
+++ b/internal/api/httpapi/server_test.go
@@ -163,6 +163,62 @@ func TestServer_RequestTimeoutReturnsGatewayTimeout(t *testing.T) {
 	}
 }
 
+func TestServer_ServiceContextRemainsAliveAfterDecode(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{
+		createSession: func(ctx context.Context, req *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+			if err := ctx.Err(); err != nil {
+				t.Fatalf("context canceled before service call: %v", err)
+			}
+			return &core.CreateSessionResponse{
+				SessionID:    "sess_abc",
+				SessionToken: "eyJ.test",
+				ExpiresAt:    time.Date(2026, 3, 12, 20, 15, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{
+		"tenant_id":"t_acme",
+		"agent_id":"agent_pr_reviewer",
+		"run_id":"run_7f9",
+		"tool_context":["github"],
+		"attestation":{"kind":"k8s_sa_jwt","token":"jwt"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(svc, httpapi.WithRequestTimeouts(time.Second, time.Second, time.Second)).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestServer_RejectsTrailingJSONValue(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{
+		"tenant_id":"t_acme",
+		"agent_id":"agent_pr_reviewer",
+		"run_id":"run_7f9",
+		"tool_context":["github"],
+		"attestation":{"kind":"k8s_sa_jwt","token":"jwt"}
+	}{"extra":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(&stubService{}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(recorder.Body.String(), "single JSON object") {
+		t.Fatalf("body = %q, want single-object error", recorder.Body.String())
+	}
+}
+
 func TestServer_RateLimitReturnsTooManyRequests(t *testing.T) {
 	t.Parallel()
 

--- a/internal/approval/notifications/notifier.go
+++ b/internal/approval/notifications/notifier.go
@@ -43,28 +43,13 @@ func NewNotifier(cfg Config) (*Notifier, error) {
 	if strings.TrimSpace(cfg.BaseURL) == "" {
 		return nil, fmt.Errorf("notifications base url is required")
 	}
-	if strings.TrimSpace(cfg.RecipientID) == "" {
-		return nil, fmt.Errorf("notifications recipient id is required")
-	}
-	if cfg.Channel == notificationsv1.DeliveryChannel_DELIVERY_CHANNEL_UNSPECIFIED {
-		return nil, fmt.Errorf("notifications channel is required")
-	}
-	if cfg.Priority == notificationsv1.Priority_PRIORITY_UNSPECIFIED {
-		cfg.Priority = notificationsv1.Priority_PRIORITY_HIGH
-	}
 	if cfg.Client == nil {
 		cfg.Client = &http.Client{Timeout: 5 * time.Second}
 	}
-
-	return &Notifier{
-		client:        notificationsv1connect.NewNotificationServiceClient(cfg.Client, strings.TrimRight(cfg.BaseURL, "/")),
-		bearerToken:   strings.TrimSpace(cfg.BearerToken),
-		workspaceID:   strings.TrimSpace(cfg.WorkspaceID),
-		recipientID:   strings.TrimSpace(cfg.RecipientID),
-		channel:       cfg.Channel,
-		priority:      cfg.Priority,
-		publicBaseURL: strings.TrimRight(strings.TrimSpace(cfg.PublicBaseURL), "/"),
-	}, nil
+	return NewNotifierWithClient(
+		notificationsv1connect.NewNotificationServiceClient(cfg.Client, strings.TrimRight(cfg.BaseURL, "/")),
+		cfg,
+	)
 }
 
 func NewNotifierWithClient(client notificationSender, cfg Config) (*Notifier, error) {


### PR DESCRIPTION
## Summary
- keep ASB HTTP request timeout cancellation scoped to the full request lifecycle instead of canceling immediately after JSON decode
- reject extra top-level JSON values as a proper 400 bad request in the JSON API
- deduplicate notifier validation/construction by delegating `NewNotifier` through `NewNotifierWithClient`

## Validation
- `go test ./internal/api/httpapi ./internal/approval/notifications ./internal/bootstrap ./internal/app -count=1`
- `go test ./... -count=1`
