### PR TITLE
Instrument session and grant metrics

### DIFF
--- a/internal/app/cleanup.go
+++ b/internal/app/cleanup.go
@@ -91,6 +91,7 @@ func (s *Service) expireApproval(ctx context.Context, approval *core.Approval) e
 	if err := s.repo.SaveApproval(ctx, approval); err != nil {
 		return fmt.Errorf("expire approval %q: save approval: %w", approval.ID, err)
 	}
+	s.metrics.recordApprovalTransition(approval.State, s.clock.Now().Sub(approval.CreatedAt))
 
 	grant, err := s.repo.GetGrant(ctx, approval.GrantID)
 	if err != nil {
@@ -101,6 +102,7 @@ func (s *Service) expireApproval(ctx context.Context, approval *core.Approval) e
 		if err := s.repo.SaveGrant(ctx, grant); err != nil {
 			return fmt.Errorf("expire approval %q: save expired grant %q: %w", approval.ID, grant.ID, err)
 		}
+		s.metrics.recordGrantTransition(grant.State)
 	}
 
 	s.appendAudit(ctx, &core.AuditEvent{
@@ -136,6 +138,7 @@ func (s *Service) expireSession(ctx context.Context, session *core.Session, stat
 	if err := s.repo.SaveSession(ctx, session); err != nil {
 		return fmt.Errorf("expire session %q: save session: %w", session.ID, err)
 	}
+	s.metrics.recordSessionTransition(core.SessionStateActive, session.State, session.TenantID)
 	stats.SessionsExpired++
 	s.appendAudit(ctx, &core.AuditEvent{
 		EventID:   s.ids.New("evt"),
@@ -187,6 +190,7 @@ func (s *Service) transitionGrantState(ctx context.Context, session *core.Sessio
 	if err := s.repo.SaveGrant(ctx, grant); err != nil {
 		return fmt.Errorf("transition grant %q to %q: save grant: %w", grant.ID, state, err)
 	}
+	s.metrics.recordGrantTransition(grant.State)
 
 	if artifact != nil {
 		switch state {

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -1,0 +1,289 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/evalops/asb/internal/core"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricsOptions configures Prometheus registration for ASB domain metrics.
+type MetricsOptions struct {
+	Registerer          prometheus.Registerer
+	GrantTTLBuckets     []float64
+	ApprovalWaitBuckets []float64
+}
+
+// Metrics records ASB domain-level counters, gauges, and histograms.
+type Metrics struct {
+	sessionsActive *prometheus.GaugeVec
+	sessionsTotal  *prometheus.CounterVec
+	grantsTotal    *prometheus.CounterVec
+	grantTTL       prometheus.Histogram
+	approvalsTotal *prometheus.CounterVec
+	approvalWait   *prometheus.HistogramVec
+}
+
+// NewMetrics creates Prometheus collectors for ASB domain metrics.
+func NewMetrics(serviceName string, opts MetricsOptions) (*Metrics, error) {
+	opts = opts.withDefaults()
+	prefix := metricsPrefix(serviceName)
+
+	sessionsActive, err := registerGaugeVec(
+		opts.Registerer,
+		prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: prefix + "_sessions_active",
+				Help: "Current number of active ASB sessions by tenant.",
+			},
+			[]string{"tenant"},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionsTotal, err := registerCounterVec(
+		opts.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_sessions_total",
+				Help: "Count of ASB sessions by lifecycle outcome.",
+			},
+			[]string{"outcome"},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	grantsTotal, err := registerCounterVec(
+		opts.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_grants_total",
+				Help: "Count of ASB grants by lifecycle outcome.",
+			},
+			[]string{"outcome"},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	grantTTL, err := registerHistogram(
+		opts.Registerer,
+		prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    prefix + "_grant_ttl_seconds",
+				Help:    "Effective TTL of ASB grants in seconds.",
+				Buckets: opts.GrantTTLBuckets,
+			},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	approvalsTotal, err := registerCounterVec(
+		opts.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_approvals_total",
+				Help: "Count of ASB approvals by outcome.",
+			},
+			[]string{"outcome"},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	approvalWait, err := registerHistogramVec(
+		opts.Registerer,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    prefix + "_approval_wait_seconds",
+				Help:    "Time spent waiting on ASB approvals in seconds.",
+				Buckets: opts.ApprovalWaitBuckets,
+			},
+			[]string{"outcome"},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Metrics{
+		sessionsActive: sessionsActive,
+		sessionsTotal:  sessionsTotal,
+		grantsTotal:    grantsTotal,
+		grantTTL:       grantTTL,
+		approvalsTotal: approvalsTotal,
+		approvalWait:   approvalWait,
+	}, nil
+}
+
+func (opts MetricsOptions) withDefaults() MetricsOptions {
+	if opts.Registerer == nil {
+		opts.Registerer = prometheus.DefaultRegisterer
+	}
+	if len(opts.GrantTTLBuckets) == 0 {
+		opts.GrantTTLBuckets = []float64{30, 60, 120, 300, 600, 900, 1800, 3600}
+	}
+	if len(opts.ApprovalWaitBuckets) == 0 {
+		opts.ApprovalWaitBuckets = []float64{1, 5, 15, 30, 60, 120, 300, 600}
+	}
+	return opts
+}
+
+func (metrics *Metrics) recordSessionCreated(tenantID string) {
+	if metrics == nil {
+		return
+	}
+	metrics.sessionsTotal.WithLabelValues("created").Inc()
+	metrics.sessionsActive.WithLabelValues(labelOrUnknown(tenantID)).Inc()
+}
+
+func (metrics *Metrics) recordSessionTransition(previous, next core.SessionState, tenantID string) {
+	if metrics == nil || previous == next {
+		return
+	}
+	switch next {
+	case core.SessionStateRevoked, core.SessionStateExpired:
+		if previous == core.SessionStateActive {
+			metrics.sessionsActive.WithLabelValues(labelOrUnknown(tenantID)).Dec()
+		}
+		metrics.sessionsTotal.WithLabelValues(string(next)).Inc()
+	}
+}
+
+func (metrics *Metrics) recordGrantCreated(state core.GrantState, ttl time.Duration) {
+	if metrics == nil {
+		return
+	}
+	if state != "" {
+		metrics.grantsTotal.WithLabelValues(string(state)).Inc()
+	}
+	if ttl > 0 {
+		metrics.grantTTL.Observe(ttl.Seconds())
+	}
+}
+
+func (metrics *Metrics) recordGrantTransition(state core.GrantState) {
+	if metrics == nil || state == "" {
+		return
+	}
+	metrics.grantsTotal.WithLabelValues(string(state)).Inc()
+}
+
+func (metrics *Metrics) recordApprovalTransition(state core.ApprovalState, wait time.Duration) {
+	if metrics == nil || state == "" {
+		return
+	}
+	switch state {
+	case core.ApprovalStateApproved, core.ApprovalStateDenied, core.ApprovalStateExpired:
+		metrics.approvalsTotal.WithLabelValues(string(state)).Inc()
+		metrics.approvalWait.WithLabelValues(string(state)).Observe(wait.Seconds())
+	}
+}
+
+func labelOrUnknown(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func metricsPrefix(serviceName string) string {
+	serviceName = strings.TrimSpace(serviceName)
+	if serviceName == "" {
+		return "service"
+	}
+
+	var builder strings.Builder
+	for index, runeValue := range serviceName {
+		switch {
+		case unicode.IsLetter(runeValue), unicode.IsDigit(runeValue):
+			builder.WriteRune(unicode.ToLower(runeValue))
+		default:
+			builder.WriteByte('_')
+		}
+		if index == 0 && unicode.IsDigit(runeValue) {
+			builder.WriteByte('_')
+		}
+	}
+
+	prefix := strings.Trim(builder.String(), "_")
+	if prefix == "" {
+		return "service"
+	}
+	if prefix[0] >= '0' && prefix[0] <= '9' {
+		return "service_" + prefix
+	}
+	return prefix
+}
+
+func registerGaugeVec(registerer prometheus.Registerer, collector *prometheus.GaugeVec) (*prometheus.GaugeVec, error) {
+	if err := registerer.Register(collector); err != nil {
+		alreadyRegistered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			return nil, err
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.GaugeVec)
+		if !ok {
+			return nil, err
+		}
+		return existing, nil
+	}
+	return collector, nil
+}
+
+func registerCounterVec(registerer prometheus.Registerer, collector *prometheus.CounterVec) (*prometheus.CounterVec, error) {
+	if err := registerer.Register(collector); err != nil {
+		alreadyRegistered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			return nil, err
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.CounterVec)
+		if !ok {
+			return nil, err
+		}
+		return existing, nil
+	}
+	return collector, nil
+}
+
+func registerHistogram(registerer prometheus.Registerer, collector prometheus.Histogram) (prometheus.Histogram, error) {
+	if err := registerer.Register(collector); err != nil {
+		alreadyRegistered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			return nil, err
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(prometheus.Histogram)
+		if !ok {
+			return nil, fmt.Errorf("register histogram: existing collector has unexpected type %T", alreadyRegistered.ExistingCollector)
+		}
+		return existing, nil
+	}
+	return collector, nil
+}
+
+func registerHistogramVec(registerer prometheus.Registerer, collector *prometheus.HistogramVec) (*prometheus.HistogramVec, error) {
+	if err := registerer.Register(collector); err != nil {
+		alreadyRegistered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			return nil, err
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.HistogramVec)
+		if !ok {
+			return nil, err
+		}
+		return existing, nil
+	}
+	return collector, nil
+}

--- a/internal/app/metrics_test.go
+++ b/internal/app/metrics_test.go
@@ -1,0 +1,508 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evalops/asb/internal/app"
+	"github.com/evalops/asb/internal/audit/memory"
+	"github.com/evalops/asb/internal/authz/policy"
+	"github.com/evalops/asb/internal/authz/toolregistry"
+	"github.com/evalops/asb/internal/core"
+	memstore "github.com/evalops/asb/internal/store/memory"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestServiceMetrics_CreateSessionAndIssueGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := testNow()
+	registry := prometheus.NewRegistry()
+	metrics, err := app.NewMetrics("asb", app.MetricsOptions{
+		Registerer:      registry,
+		GrantTTLBuckets: []float64{60, 600, 1800},
+	})
+	if err != nil {
+		t.Fatalf("NewMetrics() error = %v", err)
+	}
+
+	repo := memstore.NewRepository()
+	tools := toolregistry.New()
+	engine := policy.NewEngine()
+	signer := mustNewSigner(t)
+	connector := &fakeConnector{
+		kind: "github",
+		issued: &core.IssuedArtifact{
+			Kind: core.ArtifactKindProxyHandle,
+			Metadata: map[string]string{
+				"handle": "ph_metrics_1",
+			},
+		},
+	}
+	delivery := &fakeDeliveryAdapter{
+		mode: core.DeliveryModeProxy,
+		delivery: &core.Delivery{
+			Kind:   core.DeliveryKindProxyHandle,
+			Handle: "ph_metrics_1",
+		},
+	}
+
+	mustPutTool(t, ctx, tools, core.Tool{
+		TenantID:             "t_acme",
+		Tool:                 "github",
+		ManifestHash:         "sha256:test",
+		RuntimeClass:         core.RuntimeClassHosted,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeProxy},
+		AllowedCapabilities:  []string{"repo.read"},
+		TrustTags:            []string{"trusted", "github"},
+	})
+	mustPutPolicy(t, engine, core.Policy{
+		TenantID:             "t_acme",
+		Capability:           "repo.read",
+		ResourceKind:         core.ResourceKindGitHubRepo,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeProxy},
+		DefaultTTL:           10 * time.Minute,
+		MaxTTL:               10 * time.Minute,
+		ApprovalMode:         core.ApprovalModeNone,
+		RequiredToolTags:     []string{"trusted", "github"},
+		Condition:            `true`,
+	})
+
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		IDs:           fixedIDs("sess_metrics_1", "evt_1", "gr_metrics_1", "evt_2", "evt_3"),
+		Metrics:       metrics,
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: signer,
+		Policy:        engine,
+		Tools:         tools,
+		Connectors:    fakeConnectorResolver{connector: connector},
+		Deliveries: map[core.DeliveryMode]core.DeliveryAdapter{
+			core.DeliveryModeProxy: delivery,
+		},
+		ApprovalNotifier: noopApprovalNotifier{},
+		Audit:            memory.NewSink(),
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	sessionResp, err := svc.CreateSession(ctx, &core.CreateSessionRequest{
+		TenantID:    "t_acme",
+		AgentID:     "agent_pr_reviewer",
+		RunID:       "run_metrics_1",
+		ToolContext: []string{"github"},
+		Attestation: &core.Attestation{Kind: core.AttestationKindK8SServiceAccountJWT, Token: "jwt"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	if _, err := svc.RequestGrant(ctx, &core.RequestGrantRequest{
+		SessionToken: sessionResp.SessionToken,
+		Tool:         "github",
+		Capability:   "repo.read",
+		ResourceRef:  "github:repo:acme/widgets",
+		DeliveryMode: core.DeliveryModeProxy,
+		TTL:          20 * time.Minute,
+		Reason:       "metrics coverage",
+	}); err != nil {
+		t.Fatalf("RequestGrant() error = %v", err)
+	}
+
+	families := mustGatherMetrics(t, registry)
+	if got := metricValueWithLabels(families, "asb_sessions_active", map[string]string{"tenant": "t_acme"}); got != 1 {
+		t.Fatalf("active sessions = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_sessions_total", map[string]string{"outcome": "created"}); got != 1 {
+		t.Fatalf("created sessions = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_grants_total", map[string]string{"outcome": "issued"}); got != 1 {
+		t.Fatalf("issued grants = %v, want 1", got)
+	}
+	if got := histogramCountWithLabels(families, "asb_grant_ttl_seconds", nil); got != 1 {
+		t.Fatalf("grant TTL histogram count = %d, want 1", got)
+	}
+}
+
+func TestServiceMetrics_ApprovalFlow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := testNow()
+	registry := prometheus.NewRegistry()
+	metrics, err := app.NewMetrics("asb", app.MetricsOptions{
+		Registerer:          registry,
+		GrantTTLBuckets:     []float64{60, 300, 600},
+		ApprovalWaitBuckets: []float64{1, 60, 300},
+	})
+	if err != nil {
+		t.Fatalf("NewMetrics() error = %v", err)
+	}
+
+	repo := memstore.NewRepository()
+	auditSink := memory.NewSink()
+	tools := toolregistry.New()
+	engine := policy.NewEngine()
+	signer := mustNewSigner(t)
+	connector := &fakeConnector{
+		kind: "browser",
+		issued: &core.IssuedArtifact{
+			Kind: core.ArtifactKindWrappedSecret,
+			Metadata: map[string]string{
+				"artifact_id": "art_browser_metrics",
+			},
+			SecretData: map[string]string{
+				"username": "admin",
+				"password": "redacted",
+			},
+		},
+	}
+	delivery := &fakeDeliveryAdapter{
+		mode: core.DeliveryModeWrappedSecret,
+		delivery: &core.Delivery{
+			Kind:       core.DeliveryKindWrappedSecret,
+			ArtifactID: "art_browser_metrics",
+		},
+	}
+
+	mustPutTool(t, ctx, tools, core.Tool{
+		TenantID:             "t_acme",
+		Tool:                 "browser",
+		ManifestHash:         "sha256:browser",
+		RuntimeClass:         core.RuntimeClassBrowser,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
+		AllowedCapabilities:  []string{"browser.login"},
+		TrustTags:            []string{"trusted", "browser"},
+	})
+	mustPutPolicy(t, engine, core.Policy{
+		TenantID:             "t_acme",
+		Capability:           "browser.login",
+		ResourceKind:         core.ResourceKindBrowserOrigin,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
+		DefaultTTL:           2 * time.Minute,
+		MaxTTL:               5 * time.Minute,
+		ApprovalMode:         core.ApprovalModeLiveHuman,
+		RequiredToolTags:     []string{"trusted", "browser"},
+		Condition:            `request.origin == "https://admin.vendor.example" && session.tool_context.exists(t, t == "browser")`,
+	})
+
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		IDs:           fixedIDs("sess_browser_metrics", "evt_1", "gr_browser_metrics", "ap_browser_metrics", "evt_2", "evt_3", "art_browser_metrics", "evt_4", "evt_5"),
+		Metrics:       metrics,
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: signer,
+		Policy:        engine,
+		Tools:         tools,
+		Connectors:    fakeConnectorResolver{connector: connector},
+		Deliveries: map[core.DeliveryMode]core.DeliveryAdapter{
+			core.DeliveryModeWrappedSecret: delivery,
+		},
+		ApprovalNotifier: noopApprovalNotifier{},
+		Audit:            auditSink,
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	sessionResp, err := svc.CreateSession(ctx, &core.CreateSessionRequest{
+		TenantID:    "t_acme",
+		AgentID:     "browser_agent",
+		RunID:       "run_metrics_2",
+		ToolContext: []string{"browser"},
+		Attestation: &core.Attestation{Kind: core.AttestationKindK8SServiceAccountJWT, Token: "jwt"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	grantResp, err := svc.RequestGrant(ctx, &core.RequestGrantRequest{
+		SessionToken: sessionResp.SessionToken,
+		Tool:         "browser",
+		Capability:   "browser.login",
+		ResourceRef:  "browser_origin:https://admin.vendor.example",
+		DeliveryMode: core.DeliveryModeWrappedSecret,
+		TTL:          5 * time.Minute,
+		Reason:       "metrics browser login",
+	})
+	if err != nil {
+		t.Fatalf("RequestGrant() error = %v", err)
+	}
+	if _, err := svc.ApproveGrant(ctx, &core.ApproveGrantRequest{
+		ApprovalID: grantResp.ApprovalID,
+		Approver:   "user:jonathan",
+		Comment:    "approved for metrics",
+	}); err != nil {
+		t.Fatalf("ApproveGrant() error = %v", err)
+	}
+
+	families := mustGatherMetrics(t, registry)
+	if got := metricValueWithLabels(families, "asb_grants_total", map[string]string{"outcome": "pending"}); got != 1 {
+		t.Fatalf("pending grants = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_grants_total", map[string]string{"outcome": "issued"}); got != 1 {
+		t.Fatalf("issued grants = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_approvals_total", map[string]string{"outcome": "approved"}); got != 1 {
+		t.Fatalf("approved approvals = %v, want 1", got)
+	}
+	if got := histogramCountWithLabels(families, "asb_approval_wait_seconds", map[string]string{"outcome": "approved"}); got != 1 {
+		t.Fatalf("approval wait histogram count = %d, want 1", got)
+	}
+}
+
+func TestServiceMetrics_RevokeSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := testNow()
+	registry := prometheus.NewRegistry()
+	metrics, err := app.NewMetrics("asb", app.MetricsOptions{
+		Registerer: registry,
+	})
+	if err != nil {
+		t.Fatalf("NewMetrics() error = %v", err)
+	}
+
+	repo := memstore.NewRepository()
+	tools := toolregistry.New()
+	engine := policy.NewEngine()
+	signer := mustNewSigner(t)
+	connector := &fakeConnector{
+		kind: "github",
+		issued: &core.IssuedArtifact{
+			Kind: core.ArtifactKindProxyHandle,
+			Metadata: map[string]string{
+				"handle": "ph_metrics_revoke",
+			},
+		},
+	}
+	delivery := &fakeDeliveryAdapter{
+		mode: core.DeliveryModeProxy,
+		delivery: &core.Delivery{
+			Kind:   core.DeliveryKindProxyHandle,
+			Handle: "ph_metrics_revoke",
+		},
+	}
+
+	mustPutTool(t, ctx, tools, core.Tool{
+		TenantID:             "t_acme",
+		Tool:                 "github",
+		ManifestHash:         "sha256:test",
+		RuntimeClass:         core.RuntimeClassHosted,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeProxy},
+		AllowedCapabilities:  []string{"repo.read"},
+		TrustTags:            []string{"trusted", "github"},
+	})
+	mustPutPolicy(t, engine, core.Policy{
+		TenantID:             "t_acme",
+		Capability:           "repo.read",
+		ResourceKind:         core.ResourceKindGitHubRepo,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeProxy},
+		DefaultTTL:           10 * time.Minute,
+		MaxTTL:               10 * time.Minute,
+		ApprovalMode:         core.ApprovalModeNone,
+		RequiredToolTags:     []string{"trusted", "github"},
+		Condition:            `true`,
+	})
+
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		IDs:           fixedIDs("sess_rev_metrics", "evt_1", "gr_rev_metrics", "art_rev_metrics", "evt_2", "evt_3", "evt_4"),
+		Metrics:       metrics,
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: signer,
+		Policy:        engine,
+		Tools:         tools,
+		Connectors:    fakeConnectorResolver{connector: connector},
+		Deliveries: map[core.DeliveryMode]core.DeliveryAdapter{
+			core.DeliveryModeProxy: delivery,
+		},
+		ApprovalNotifier: noopApprovalNotifier{},
+		Audit:            memory.NewSink(),
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	sessionResp, err := svc.CreateSession(ctx, &core.CreateSessionRequest{
+		TenantID:    "t_acme",
+		AgentID:     "agent_pr_reviewer",
+		RunID:       "run_metrics_3",
+		ToolContext: []string{"github"},
+		Attestation: &core.Attestation{Kind: core.AttestationKindK8SServiceAccountJWT, Token: "jwt"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	grantResp, err := svc.RequestGrant(ctx, &core.RequestGrantRequest{
+		SessionToken: sessionResp.SessionToken,
+		Tool:         "github",
+		Capability:   "repo.read",
+		ResourceRef:  "github:repo:acme/widgets",
+		DeliveryMode: core.DeliveryModeProxy,
+		TTL:          10 * time.Minute,
+		Reason:       "revoke metrics",
+	})
+	if err != nil {
+		t.Fatalf("RequestGrant() error = %v", err)
+	}
+	if err := svc.RevokeSession(ctx, &core.RevokeSessionRequest{
+		SessionID: sessionResp.SessionID,
+		Reason:    "run_cancelled",
+	}); err != nil {
+		t.Fatalf("RevokeSession() error = %v", err)
+	}
+
+	families := mustGatherMetrics(t, registry)
+	if got := metricValueWithLabels(families, "asb_sessions_active", map[string]string{"tenant": "t_acme"}); got != 0 {
+		t.Fatalf("active sessions = %v, want 0", got)
+	}
+	if got := metricValueWithLabels(families, "asb_sessions_total", map[string]string{"outcome": "revoked"}); got != 1 {
+		t.Fatalf("revoked sessions = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_grants_total", map[string]string{"outcome": "revoked"}); got != 1 {
+		t.Fatalf("revoked grants = %v, want 1", got)
+	}
+	grant, err := repo.GetGrant(ctx, grantResp.GrantID)
+	if err != nil {
+		t.Fatalf("GetGrant() error = %v", err)
+	}
+	if grant.State != core.GrantStateRevoked {
+		t.Fatalf("grant state = %q, want revoked", grant.State)
+	}
+}
+
+func TestServiceMetrics_ExpireApprovalAndGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 3, 12, 20, 0, 0, 0, time.UTC)
+	registry := prometheus.NewRegistry()
+	metrics, err := app.NewMetrics("asb", app.MetricsOptions{
+		Registerer: registry,
+	})
+	if err != nil {
+		t.Fatalf("NewMetrics() error = %v", err)
+	}
+
+	repo := memstore.NewRepository()
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		IDs:           fixedIDs("evt_1"),
+		Metrics:       metrics,
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: mustNewSigner(t),
+		Policy:        stubPolicyEngine{},
+		Tools:         stubToolRegistry{},
+		Connectors:    fakeConnectorResolver{connector: &fakeConnector{kind: "browser"}},
+		Audit:         memory.NewSink(),
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	if err := repo.SaveGrant(ctx, &core.Grant{
+		ID:        "gr_pending",
+		TenantID:  "t_acme",
+		SessionID: "sess_pending",
+		State:     core.GrantStatePending,
+		CreatedAt: now.Add(-10 * time.Minute),
+		ExpiresAt: now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveGrant() error = %v", err)
+	}
+	if err := repo.SaveApproval(ctx, &core.Approval{
+		ID:          "ap_1",
+		TenantID:    "t_acme",
+		GrantID:     "gr_pending",
+		RequestedBy: "browser_agent",
+		State:       core.ApprovalStatePending,
+		ExpiresAt:   now.Add(-1 * time.Minute),
+		CreatedAt:   now.Add(-10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveApproval() error = %v", err)
+	}
+
+	if _, err := svc.RunCleanupOnce(ctx, 100); err != nil {
+		t.Fatalf("RunCleanupOnce() error = %v", err)
+	}
+
+	families := mustGatherMetrics(t, registry)
+	if got := metricValueWithLabels(families, "asb_approvals_total", map[string]string{"outcome": "expired"}); got != 1 {
+		t.Fatalf("expired approvals = %v, want 1", got)
+	}
+	if got := metricValueWithLabels(families, "asb_grants_total", map[string]string{"outcome": "expired"}); got != 1 {
+		t.Fatalf("expired grants = %v, want 1", got)
+	}
+	if got := histogramCountWithLabels(families, "asb_approval_wait_seconds", map[string]string{"outcome": "expired"}); got != 1 {
+		t.Fatalf("approval wait histogram count = %d, want 1", got)
+	}
+}
+
+func mustGatherMetrics(t *testing.T, gatherer prometheus.Gatherer) []*dto.MetricFamily {
+	t.Helper()
+
+	families, err := gatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	return families
+}
+
+func metricValueWithLabels(metricFamilies []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	for _, family := range metricFamilies {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if !metricMatchesLabels(metric, labels) {
+				continue
+			}
+			switch family.GetType() {
+			case dto.MetricType_COUNTER:
+				return metric.GetCounter().GetValue()
+			case dto.MetricType_GAUGE:
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func histogramCountWithLabels(metricFamilies []*dto.MetricFamily, name string, labels map[string]string) uint64 {
+	for _, family := range metricFamilies {
+		if family.GetName() != name || family.GetType() != dto.MetricType_HISTOGRAM {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if metricMatchesLabels(metric, labels) {
+				return metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func metricMatchesLabels(metric *dto.Metric, labels map[string]string) bool {
+	if len(labels) == 0 {
+		return true
+	}
+	values := make(map[string]string, len(metric.Label))
+	for _, label := range metric.Label {
+		values[label.GetName()] = label.GetValue()
+	}
+	for key, want := range labels {
+		if values[key] != want {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -24,6 +24,7 @@ type Config struct {
 	Logger              *slog.Logger
 	Clock               core.Clock
 	IDs                 core.IDGenerator
+	Metrics             *Metrics
 	Repository          core.Repository
 	Verifier            core.AttestationVerifier
 	DelegationValidator core.DelegationValidator
@@ -42,6 +43,7 @@ type Service struct {
 	logger              *slog.Logger
 	clock               core.Clock
 	ids                 core.IDGenerator
+	metrics             *Metrics
 	repo                core.Repository
 	verifier            core.AttestationVerifier
 	delegationValidator core.DelegationValidator
@@ -77,6 +79,7 @@ func NewService(cfg Config) (*Service, error) {
 		logger:              cfg.Logger,
 		clock:               cfg.Clock,
 		ids:                 cfg.IDs,
+		metrics:             cfg.Metrics,
 		repo:                cfg.Repository,
 		verifier:            cfg.Verifier,
 		delegationValidator: cfg.DelegationValidator,
@@ -130,6 +133,7 @@ func (s *Service) CreateSession(ctx context.Context, req *core.CreateSessionRequ
 	if err := s.repo.SaveSession(ctx, session); err != nil {
 		return nil, fmt.Errorf("create session %q: save session: %w", session.ID, err)
 	}
+	s.metrics.recordSessionCreated(session.TenantID)
 
 	if delegation != nil {
 		s.appendAudit(ctx, &core.AuditEvent{
@@ -262,6 +266,7 @@ func (s *Service) RequestGrant(ctx context.Context, req *core.RequestGrantReques
 		if err := s.repo.SaveApproval(ctx, approval); err != nil {
 			return nil, fmt.Errorf("request grant %q: save pending approval %q: %w", grant.ID, approval.ID, err)
 		}
+		s.metrics.recordGrantCreated(grant.State, grant.EffectiveTTL)
 		s.appendAudit(ctx, &core.AuditEvent{
 			EventID:     s.ids.New("evt"),
 			TenantID:    session.TenantID,
@@ -312,6 +317,7 @@ func (s *Service) ApproveGrant(ctx context.Context, req *core.ApproveGrantReques
 		if err := s.repo.SaveApproval(ctx, approval); err != nil {
 			return nil, fmt.Errorf("approve grant via approval %q: expire approval: %w", req.ApprovalID, err)
 		}
+		s.metrics.recordApprovalTransition(approval.State, s.clock.Now().Sub(approval.CreatedAt))
 		return nil, fmt.Errorf("%w: approval expired", core.ErrForbidden)
 	}
 
@@ -331,6 +337,7 @@ func (s *Service) ApproveGrant(ctx context.Context, req *core.ApproveGrantReques
 	if err := s.repo.SaveApproval(ctx, approval); err != nil {
 		return nil, fmt.Errorf("approve grant %q: save approved approval %q: %w", grant.ID, approval.ID, err)
 	}
+	s.metrics.recordApprovalTransition(approval.State, s.clock.Now().Sub(approval.CreatedAt))
 
 	s.appendAudit(ctx, &core.AuditEvent{
 		EventID:   s.ids.New("evt"),
@@ -383,6 +390,8 @@ func (s *Service) DenyGrant(ctx context.Context, req *core.DenyGrantRequest) err
 	if err := s.repo.SaveGrant(ctx, grant); err != nil {
 		return fmt.Errorf("deny grant %q: save denied grant: %w", grant.ID, err)
 	}
+	s.metrics.recordApprovalTransition(approval.State, s.clock.Now().Sub(approval.CreatedAt))
+	s.metrics.recordGrantTransition(grant.State)
 
 	s.appendAudit(ctx, &core.AuditEvent{
 		EventID:   s.ids.New("evt"),
@@ -423,10 +432,12 @@ func (s *Service) RevokeSession(ctx context.Context, req *core.RevokeSessionRequ
 	if err != nil {
 		return fmt.Errorf("revoke session %q: load session: %w", req.SessionID, err)
 	}
+	previousState := session.State
 	session.State = core.SessionStateRevoked
 	if err := s.repo.SaveSession(ctx, session); err != nil {
 		return fmt.Errorf("revoke session %q: save session: %w", session.ID, err)
 	}
+	s.metrics.recordSessionTransition(previousState, session.State, session.TenantID)
 
 	grants, err := s.repo.ListGrantsBySession(ctx, req.SessionID)
 	if err != nil {
@@ -743,6 +754,11 @@ func (s *Service) issueGrant(ctx context.Context, session *core.Session, grant *
 	if err := s.repo.SaveGrant(ctx, grant); err != nil {
 		return nil, fmt.Errorf("issue grant %q: save issued grant: %w", grant.ID, err)
 	}
+	if grant.ApprovalID != nil {
+		s.metrics.recordGrantTransition(grant.State)
+	} else {
+		s.metrics.recordGrantCreated(grant.State, grant.EffectiveTTL)
+	}
 
 	s.appendAudit(ctx, &core.AuditEvent{
 		EventID:     s.ids.New("evt"),
@@ -796,10 +812,12 @@ func (s *Service) loadActiveSession(ctx context.Context, raw string) (*core.Sess
 		return nil, nil, fmt.Errorf("%w: session is not active", core.ErrForbidden)
 	}
 	if s.clock.Now().After(session.ExpiresAt) {
+		previousState := session.State
 		session.State = core.SessionStateExpired
 		if err := s.repo.SaveSession(ctx, session); err != nil {
 			return nil, nil, fmt.Errorf("load active session %q: expire session: %w", session.ID, err)
 		}
+		s.metrics.recordSessionTransition(previousState, session.State, session.TenantID)
 		return nil, nil, fmt.Errorf("%w: session expired", core.ErrForbidden)
 	}
 	return session, claims, nil

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -36,6 +36,7 @@ import (
 	redisstore "github.com/evalops/asb/internal/store/redis"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -233,6 +234,14 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 		cleanupRepository()
 		return nil, err
 	}
+	metrics, err := app.NewMetrics("asb", app.MetricsOptions{
+		Registerer: prometheus.DefaultRegisterer,
+	})
+	if err != nil {
+		cleanupRuntime()
+		cleanupRepository()
+		return nil, err
+	}
 
 	svc, err := app.NewService(app.Config{
 		Logger:              logger,
@@ -240,6 +249,7 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 		Verifier:            verifier,
 		DelegationValidator: delegationValidator,
 		SessionTokens:       sessionTokens,
+		Metrics:             metrics,
 		Policy:              engine,
 		Tools:               tools,
 		Connectors:          resolver.NewStaticResolver(connectorOptions...),


### PR DESCRIPTION
## Summary
- add ASB domain metrics for sessions, grants, and approvals under internal/app
- wire the app metrics into bootstrap so they register on the existing `/metrics` endpoint
- cover create, approval, revoke, and expiry paths with Prometheus-backed tests

## Testing
- go test ./internal/app
- go test ./internal/bootstrap ./cmd/asb-api ./internal/api/httpapi
- go test ./...
- git diff --check