### PR TITLE
Address remaining ASB review cleanups

### DIFF
--- a/cmd/asb-api/config.go
+++ b/cmd/asb-api/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -139,6 +140,9 @@ func parsePositiveFloatEnv(key string, fallback float64) (float64, error) {
 	value, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
 		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("%s must be finite", key)
 	}
 	if value <= 0 {
 		return 0, fmt.Errorf("%s must be greater than zero", key)

--- a/cmd/asb-api/config_test.go
+++ b/cmd/asb-api/config_test.go
@@ -89,3 +89,15 @@ func TestLoadServerConfigRejectsInvalidValues(t *testing.T) {
 		t.Fatal("loadServerConfig() error = nil, want non-nil")
 	}
 }
+
+func TestLoadServerConfigRejectsNonFiniteRateLimit(t *testing.T) {
+	for _, raw := range []string{"NaN", "Inf", "-Inf"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("ASB_HTTP_RATE_LIMIT_RPS", raw)
+
+			if _, err := loadServerConfig(); err == nil {
+				t.Fatalf("loadServerConfig() error = nil for %q, want non-nil", raw)
+			}
+		})
+	}
+}

--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -28,6 +28,7 @@ type Service interface {
 
 type Server struct {
 	service     Service
+	handler     http.Handler
 	maxBody     int64
 	timeouts    requestTimeouts
 	rateLimiter *ratelimit.Limiter
@@ -64,6 +65,10 @@ func NewServer(service Service, options ...Option) *Server {
 	for _, option := range options {
 		option(server)
 	}
+	server.handler = http.HandlerFunc(server.serveHTTP)
+	if server.rateLimiter != nil {
+		server.handler = server.rateLimiter.Middleware(server.handler)
+	}
 	return server
 }
 
@@ -96,11 +101,11 @@ func WithRateLimiter(limiter *ratelimit.Limiter) Option {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if s.rateLimiter != nil {
-		s.rateLimiter.Middleware(http.HandlerFunc(s.serveHTTP)).ServeHTTP(w, r)
+	if s.handler == nil {
+		s.serveHTTP(w, r)
 		return
 	}
-	s.serveHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }
 
 func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -142,9 +142,9 @@ func NewMetrics(serviceName string, opts MetricsOptions) (*Metrics, error) {
 		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: prefix + "_budget_exhaustion_total",
-				Help: "Count of ASB proxy budget exhaustion events by handle.",
+				Help: "Count of ASB proxy budget exhaustion events by connector kind.",
 			},
-			[]string{"handle"},
+			[]string{"connector_kind"},
 		),
 	)
 	if err != nil {
@@ -299,11 +299,11 @@ func (metrics *Metrics) recordPolicyEvaluation(capability string, allowed bool) 
 	metrics.policyEval.WithLabelValues(labelOrUnknown(capability), outcome).Inc()
 }
 
-func (metrics *Metrics) recordBudgetExhaustion(handle string) {
+func (metrics *Metrics) recordBudgetExhaustion(connectorKind string) {
 	if metrics == nil {
 		return
 	}
-	metrics.budgetExhaust.WithLabelValues(labelOrUnknown(handle)).Inc()
+	metrics.budgetExhaust.WithLabelValues(labelOrUnknown(connectorKind)).Inc()
 }
 
 func (metrics *Metrics) recordArtifactCreated(connectorKind string) {

--- a/internal/app/metrics_test.go
+++ b/internal/app/metrics_test.go
@@ -674,7 +674,7 @@ func TestServiceMetrics_BudgetExhaustion(t *testing.T) {
 	}
 
 	families := mustGatherMetrics(t, registry)
-	if got := metricValueWithLabels(families, "asb_budget_exhaustion_total", map[string]string{"handle": "ph_budget_metrics"}); got != 1 {
+	if got := metricValueWithLabels(families, "asb_budget_exhaustion_total", map[string]string{"connector_kind": "github"}); got != 1 {
 		t.Fatalf("budget exhaustion count = %v, want 1", got)
 	}
 }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -509,7 +509,7 @@ func (s *Service) ExecuteGitHubProxy(ctx context.Context, req *core.ExecuteGitHu
 	if s.runtime != nil {
 		if err := s.runtime.AcquireProxyRequest(ctx, req.ProxyHandle); err != nil {
 			if errors.Is(err, core.ErrResourceBudgetExceeded) {
-				s.metrics.recordBudgetExhaustion(req.ProxyHandle)
+				s.metrics.recordBudgetExhaustion(artifact.ConnectorKind)
 			}
 			return nil, fmt.Errorf("execute github proxy %q: acquire proxy request budget: %w", req.ProxyHandle, err)
 		}
@@ -545,7 +545,7 @@ func (s *Service) ExecuteGitHubProxy(ctx context.Context, req *core.ExecuteGitHu
 	if acquired && s.runtime != nil {
 		if err := s.runtime.CompleteProxyRequest(cleanupCtx, req.ProxyHandle, responseBytes); err != nil {
 			if errors.Is(err, core.ErrResourceBudgetExceeded) {
-				s.metrics.recordBudgetExhaustion(req.ProxyHandle)
+				s.metrics.recordBudgetExhaustion(artifact.ConnectorKind)
 			}
 			return nil, fmt.Errorf("execute github proxy %q operation %q: release proxy request budget: %w", req.ProxyHandle, req.Operation, err)
 		}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -479,13 +479,16 @@ func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), readinessP
 			Password: os.Getenv("ASB_REDIS_PASSWORD"),
 			DB:       0,
 		})
+		closeClient := func() { _ = client.Close() }
 		if err := instrumentDefaultRedisClient(client); err != nil {
+			closeClient()
 			return nil, nil, nil, nil, err
 		}
 		if err := client.Ping(ctx).Err(); err != nil {
+			closeClient()
 			return nil, nil, nil, nil, err
 		}
-		return redisstore.NewRuntimeStore(client), func() { _ = client.Close() }, func(ctx context.Context) error {
+		return redisstore.NewRuntimeStore(client), closeClient, func(ctx context.Context) error {
 			return client.Ping(ctx).Err()
 		}, redisPoolStats(client), nil
 	}
@@ -507,7 +510,7 @@ func pgxPoolDBStats(pool *pgxpool.Pool) func() sql.DBStats {
 	}
 }
 
-func redisPoolStats(client goredis.UniversalClient) func() *goredis.PoolStats {
+func redisPoolStats(client *goredis.Client) func() *goredis.PoolStats {
 	if client == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- reject non-finite rate limit config values and cover them in tests
- bound budget exhaustion metric labels by connector kind instead of proxy handle
- close redis clients on bootstrap error paths and prebuild the HTTP rate-limit middleware once

## Testing
- go test ./cmd/asb-api ./internal/app ./internal/bootstrap ./internal/api/httpapi -count=1
- go test ./... -count=1