### PR TITLE
Defer minted-token delivery explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ A static resolver routes capability and resource kind to the appropriate connect
 
 - **`proxy`**: the broker executes the downstream call and the agent only receives an opaque handle. The agent never sees the credential. Budget-enforced per handle.
 - **`wrapped_secret`**: the broker returns a short-lived, single-use artifact reference for trusted runtimes. The artifact is bound to recipient identity (session, key, origin, tab).
-- **`minted_token`** *(planned, not runtime-enabled)*: direct short-lived token issuance for cases where proxy is impractical. Modeled in the domain types but not wired into delivery adapters.
+- **`minted_token`** *(planned, not runtime-enabled)*: direct short-lived token issuance for cases where proxy is impractical. Modeled in the domain types but currently rejected with an explicit not-implemented error until runtime support lands.
 
 ## Storage
 

--- a/internal/api/connectapi/server.go
+++ b/internal/api/connectapi/server.go
@@ -217,6 +217,8 @@ func connectError(err error) error {
 	switch {
 	case errors.Is(err, core.ErrInvalidRequest):
 		code = connect.CodeInvalidArgument
+	case errors.Is(err, core.ErrDeliveryModeNotImplemented):
+		code = connect.CodeUnimplemented
 	case errors.Is(err, core.ErrUnauthorized):
 		code = connect.CodeUnauthenticated
 	case errors.Is(err, core.ErrForbidden):

--- a/internal/api/connectapi/server_test.go
+++ b/internal/api/connectapi/server_test.go
@@ -83,29 +83,45 @@ func TestServer_CreateSessionAndExecuteProxy(t *testing.T) {
 func TestServer_MapsCoreErrorsToConnectCodes(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubService{
-		createSession: func(context.Context, *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
-			return nil, core.ErrInvalidRequest
-		},
+	tests := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{name: "invalid request", err: core.ErrInvalidRequest, want: connect.CodeInvalidArgument},
+		{name: "unimplemented delivery mode", err: core.ErrDeliveryModeNotImplemented, want: connect.CodeUnimplemented},
 	}
 
-	path, handler := connectapi.NewHandler(svc)
-	mux := http.NewServeMux()
-	mux.Handle(path, handler)
-	server := httptest.NewServer(mux)
-	defer server.Close()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	client := asbv1connect.NewBrokerServiceClient(server.Client(), server.URL)
-	_, err := client.CreateSession(context.Background(), connect.NewRequest(&asbv1.CreateSessionRequest{}))
-	if err == nil {
-		t.Fatal("CreateSession() error = nil, want non-nil")
-	}
-	var connectErr *connect.Error
-	if !errors.As(err, &connectErr) {
-		t.Fatalf("error = %T, want *connect.Error", err)
-	}
-	if connectErr.Code() != connect.CodeInvalidArgument {
-		t.Fatalf("code = %v, want %v", connectErr.Code(), connect.CodeInvalidArgument)
+			svc := &stubService{
+				createSession: func(context.Context, *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+					return nil, tt.err
+				},
+			}
+
+			path, handler := connectapi.NewHandler(svc)
+			mux := http.NewServeMux()
+			mux.Handle(path, handler)
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := asbv1connect.NewBrokerServiceClient(server.Client(), server.URL)
+			_, err := client.CreateSession(context.Background(), connect.NewRequest(&asbv1.CreateSessionRequest{}))
+			if err == nil {
+				t.Fatal("CreateSession() error = nil, want non-nil")
+			}
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				t.Fatalf("error = %T, want *connect.Error", err)
+			}
+			if connectErr.Code() != tt.want {
+				t.Fatalf("code = %v, want %v", connectErr.Code(), tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -378,6 +378,8 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusBadRequest
 	case errors.Is(err, core.ErrInvalidRequest):
 		status = http.StatusBadRequest
+	case errors.Is(err, core.ErrDeliveryModeNotImplemented):
+		status = http.StatusNotImplemented
 	case errors.Is(err, core.ErrUnauthorized):
 		status = http.StatusUnauthorized
 	case errors.Is(err, core.ErrForbidden):

--- a/internal/api/httpapi/server_test.go
+++ b/internal/api/httpapi/server_test.go
@@ -163,6 +163,26 @@ func TestServer_RequestTimeoutReturnsGatewayTimeout(t *testing.T) {
 	}
 }
 
+func TestServer_MapsDeliveryModeNotImplementedToNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{
+		createSession: func(context.Context, *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+			return nil, core.ErrDeliveryModeNotImplemented
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(svc).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotImplemented)
+	}
+}
+
 func TestServer_ServiceContextRemainsAliveAfterDecode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -217,6 +217,9 @@ func (s *Service) RequestGrant(ctx context.Context, req *core.RequestGrantReques
 	if !decision.Allowed {
 		return nil, fmt.Errorf("%w: %s", core.ErrForbidden, decision.Reason)
 	}
+	if err := s.validateDeliveryMode(req.DeliveryMode); err != nil {
+		return nil, fmt.Errorf("request grant for session %q: validate delivery mode %q: %w", session.ID, req.DeliveryMode, err)
+	}
 
 	now := s.clock.Now()
 	grant := &core.Grant{
@@ -326,6 +329,9 @@ func (s *Service) ApproveGrant(ctx context.Context, req *core.ApproveGrantReques
 	grant, err := s.repo.GetGrant(ctx, approval.GrantID)
 	if err != nil {
 		return nil, fmt.Errorf("approve grant via approval %q: load grant %q: %w", req.ApprovalID, approval.GrantID, err)
+	}
+	if err := s.validateDeliveryMode(grant.DeliveryMode); err != nil {
+		return nil, fmt.Errorf("approve grant %q: validate delivery mode %q: %w", grant.ID, grant.DeliveryMode, err)
 	}
 	session, err := s.repo.GetSession(ctx, grant.SessionID)
 	if err != nil {
@@ -700,6 +706,10 @@ func (s *Service) UnwrapArtifact(ctx context.Context, req *core.UnwrapArtifactRe
 }
 
 func (s *Service) issueGrant(ctx context.Context, session *core.Session, grant *core.Grant, resource core.ResourceDescriptor, connector core.Connector) (*core.RequestGrantResponse, error) {
+	if err := s.validateDeliveryMode(grant.DeliveryMode); err != nil {
+		return nil, fmt.Errorf("issue grant %q: validate delivery mode %q: %w", grant.ID, grant.DeliveryMode, err)
+	}
+
 	startedAt := time.Now()
 	artifact, err := connector.Issue(ctx, core.IssueRequest{
 		Session:  session,
@@ -711,10 +721,7 @@ func (s *Service) issueGrant(ctx context.Context, session *core.Session, grant *
 		return nil, fmt.Errorf("issue grant %q: connector %q issue: %w", grant.ID, connector.Kind(), err)
 	}
 
-	adapter, ok := s.deliveries[grant.DeliveryMode]
-	if !ok {
-		return nil, fmt.Errorf("%w: no delivery adapter for mode %q", core.ErrInvalidRequest, grant.DeliveryMode)
-	}
+	adapter := s.deliveries[grant.DeliveryMode]
 
 	delivery, err := adapter.Deliver(ctx, artifact, session, grant)
 	if err != nil {
@@ -808,6 +815,16 @@ func (s *Service) issueGrant(ctx context.Context, session *core.Session, grant *
 		Delivery:  delivery,
 		ExpiresAt: grant.ExpiresAt,
 	}, nil
+}
+
+func (s *Service) validateDeliveryMode(mode core.DeliveryMode) error {
+	if mode == core.DeliveryModeMintedToken {
+		return fmt.Errorf("%w: %q", core.ErrDeliveryModeNotImplemented, mode)
+	}
+	if _, ok := s.deliveries[mode]; !ok {
+		return fmt.Errorf("%w: no delivery adapter for mode %q", core.ErrInvalidRequest, mode)
+	}
+	return nil
 }
 
 func (s *Service) loadActiveSession(ctx context.Context, raw string) (*core.Session, *core.SessionClaims, error) {

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,6 +263,204 @@ func TestService_BrowserGrantRequiresApprovalBeforeIssue(t *testing.T) {
 	}
 	if connector.issues != 1 {
 		t.Fatalf("connector issues after approval = %d, want 1", connector.issues)
+	}
+}
+
+func TestService_RequestGrantMintedTokenReturnsNotImplementedBeforePersistingApproval(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := testNow()
+	repo := memstore.NewRepository()
+	tools := toolregistry.New()
+	engine := policy.NewEngine()
+	signer := mustNewSigner(t)
+	connector := &fakeConnector{
+		kind: "github",
+		issued: &core.IssuedArtifact{
+			Kind: core.ArtifactKindMintedToken,
+			SecretData: map[string]string{
+				"token": "ghs_test",
+			},
+		},
+	}
+
+	mustPutTool(t, ctx, tools, core.Tool{
+		TenantID:             "t_acme",
+		Tool:                 "github",
+		ManifestHash:         "sha256:minted",
+		RuntimeClass:         core.RuntimeClassHosted,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeMintedToken},
+		AllowedCapabilities:  []string{"repo.read"},
+		TrustTags:            []string{"trusted", "github"},
+	})
+	mustPutPolicy(t, engine, core.Policy{
+		TenantID:             "t_acme",
+		Capability:           "repo.read",
+		ResourceKind:         core.ResourceKindGitHubRepo,
+		AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeMintedToken},
+		DefaultTTL:           2 * time.Minute,
+		MaxTTL:               5 * time.Minute,
+		ApprovalMode:         core.ApprovalModeLiveHuman,
+		RequiredToolTags:     []string{"trusted", "github"},
+		Condition:            `true`,
+	})
+
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		IDs:           fixedIDs("sess_minted", "evt_session"),
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: signer,
+		Policy:        engine,
+		Tools:         tools,
+		Connectors:    fakeConnectorResolver{connector: connector},
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	sessionResp, err := svc.CreateSession(ctx, &core.CreateSessionRequest{
+		TenantID:    "t_acme",
+		AgentID:     "agent_pr_reviewer",
+		RunID:       "run_minted",
+		ToolContext: []string{"github"},
+		Attestation: &core.Attestation{Kind: core.AttestationKindK8SServiceAccountJWT, Token: "jwt"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	_, err = svc.RequestGrant(ctx, &core.RequestGrantRequest{
+		SessionToken: sessionResp.SessionToken,
+		Tool:         "github",
+		Capability:   "repo.read",
+		ResourceRef:  "github:repo:acme/widgets",
+		DeliveryMode: core.DeliveryModeMintedToken,
+		TTL:          5 * time.Minute,
+		Reason:       "mint direct token",
+	})
+	if err == nil {
+		t.Fatal("RequestGrant() error = nil, want non-nil")
+	}
+	if !errors.Is(err, core.ErrDeliveryModeNotImplemented) {
+		t.Fatalf("RequestGrant() error = %v, want ErrDeliveryModeNotImplemented", err)
+	}
+	if !strings.Contains(err.Error(), "validate delivery mode") {
+		t.Fatalf("RequestGrant() error = %q, want delivery-mode context", err)
+	}
+	if connector.issues != 0 {
+		t.Fatalf("connector issues = %d, want 0", connector.issues)
+	}
+
+	grants, err := repo.ListGrantsBySession(ctx, sessionResp.SessionID)
+	if err != nil {
+		t.Fatalf("ListGrantsBySession() error = %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("grants = %d, want 0", len(grants))
+	}
+	if _, err := repo.GetApproval(ctx, "ap_minted"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetApproval() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestService_ApproveGrantMintedTokenReturnsNotImplementedWithoutMutatingApproval(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := testNow()
+	repo := memstore.NewRepository()
+	signer := mustNewSigner(t)
+	connector := &fakeConnector{
+		kind: "github",
+		issued: &core.IssuedArtifact{
+			Kind: core.ArtifactKindMintedToken,
+			SecretData: map[string]string{
+				"token": "ghs_test",
+			},
+		},
+	}
+
+	svc, err := app.NewService(app.Config{
+		Clock:         fixedClock(now),
+		Repository:    repo,
+		Verifier:      fakeVerifier{identity: workloadIdentity()},
+		SessionTokens: signer,
+		Policy:        stubPolicyEngine{},
+		Tools:         stubToolRegistry{},
+		Connectors:    fakeConnectorResolver{connector: connector},
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	session := &core.Session{
+		ID:        "sess_pending_minted",
+		TenantID:  "t_acme",
+		AgentID:   "agent_pr_reviewer",
+		RunID:     "run_pending_minted",
+		State:     core.SessionStateActive,
+		ExpiresAt: now.Add(10 * time.Minute),
+		CreatedAt: now,
+	}
+	approvalID := "ap_pending_minted"
+	grant := &core.Grant{
+		ID:           "gr_pending_minted",
+		TenantID:     "t_acme",
+		SessionID:    session.ID,
+		Tool:         "github",
+		Capability:   "repo.read",
+		ResourceRef:  "github:repo:acme/widgets",
+		DeliveryMode: core.DeliveryModeMintedToken,
+		ApprovalID:   &approvalID,
+		State:        core.GrantStatePending,
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(10 * time.Minute),
+	}
+	approval := &core.Approval{
+		ID:          approvalID,
+		TenantID:    "t_acme",
+		GrantID:     grant.ID,
+		RequestedBy: "agent_pr_reviewer",
+		State:       core.ApprovalStatePending,
+		ExpiresAt:   now.Add(5 * time.Minute),
+		CreatedAt:   now,
+	}
+	if err := repo.SaveSession(ctx, session); err != nil {
+		t.Fatalf("SaveSession() error = %v", err)
+	}
+	if err := repo.SaveGrant(ctx, grant); err != nil {
+		t.Fatalf("SaveGrant() error = %v", err)
+	}
+	if err := repo.SaveApproval(ctx, approval); err != nil {
+		t.Fatalf("SaveApproval() error = %v", err)
+	}
+
+	_, err = svc.ApproveGrant(ctx, &core.ApproveGrantRequest{
+		ApprovalID: approval.ID,
+		Approver:   "user:jonathan",
+		Comment:    "ship it",
+	})
+	if err == nil {
+		t.Fatal("ApproveGrant() error = nil, want non-nil")
+	}
+	if !errors.Is(err, core.ErrDeliveryModeNotImplemented) {
+		t.Fatalf("ApproveGrant() error = %v, want ErrDeliveryModeNotImplemented", err)
+	}
+	if connector.issues != 0 {
+		t.Fatalf("connector issues = %d, want 0", connector.issues)
+	}
+
+	storedApproval, err := repo.GetApproval(ctx, approval.ID)
+	if err != nil {
+		t.Fatalf("GetApproval() error = %v", err)
+	}
+	if storedApproval.State != core.ApprovalStatePending {
+		t.Fatalf("approval state = %q, want %q", storedApproval.State, core.ApprovalStatePending)
+	}
+	if storedApproval.ApprovedBy != nil {
+		t.Fatalf("approved_by = %v, want nil", *storedApproval.ApprovedBy)
 	}
 }
 

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -3,9 +3,10 @@ package core
 import "errors"
 
 var (
-	ErrInvalidRequest         = errors.New("invalid request")
-	ErrNotFound               = errors.New("not found")
-	ErrUnauthorized           = errors.New("unauthorized")
-	ErrForbidden              = errors.New("forbidden")
-	ErrResourceBudgetExceeded = errors.New("resource budget exceeded")
+	ErrInvalidRequest             = errors.New("invalid request")
+	ErrNotFound                   = errors.New("not found")
+	ErrUnauthorized               = errors.New("unauthorized")
+	ErrForbidden                  = errors.New("forbidden")
+	ErrDeliveryModeNotImplemented = errors.New("delivery mode not implemented")
+	ErrResourceBudgetExceeded     = errors.New("resource budget exceeded")
 )


### PR DESCRIPTION
## Summary
- add a dedicated `ErrDeliveryModeNotImplemented` path for `minted_token`
- reject unsupported minted-token requests before grants or approvals are persisted
- map the defer path to `501 Not Implemented` / Connect `Unimplemented` and document the behavior

## Testing
- go test ./internal/app -run 'TestService_(RequestGrantMintedTokenReturnsNotImplementedBeforePersistingApproval|ApproveGrantMintedTokenReturnsNotImplementedWithoutMutatingApproval)$' -count=1
- go test ./internal/api/httpapi ./internal/api/connectapi -count=1
- go test ./... -count=1

Closes #19