### PR TITLE
[codex] Add Go pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 
-.PHONY: fmt test vet proto proto-check migrate run-api run-worker
+.PHONY: fmt test vet lint install-hooks proto proto-check migrate run-api run-worker
 
 fmt:
 	$(GO) fmt ./...
@@ -10,6 +10,8 @@ test:
 
 vet:
 	$(GO) vet ./...
+
+lint: vet
 
 proto:
 	bash scripts/sync-proto.sh
@@ -25,3 +27,8 @@ run-api:
 
 run-worker:
 	$(GO) run ./cmd/asb-worker
+
+install-hooks:
+	cp scripts/pre-commit .git/hooks/pre-commit
+	chmod +x .git/hooks/pre-commit
+	@echo "Pre-commit hook installed"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+mapfile -t staged_go_files < <(git diff --cached --name-only --diff-filter=ACM -- '*.go')
+if [ ${#staged_go_files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+stashed=0
+cleanup() {
+  if [ "$stashed" -eq 1 ]; then
+    git stash pop -q >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if ! git diff --quiet -- . || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  git stash push -q --keep-index --include-untracked -m "pre-commit-$(date +%s)"
+  stashed=1
+fi
+
+echo "Running gofmt on staged files..."
+gofmt -w "${staged_go_files[@]}"
+git add -- "${staged_go_files[@]}"
+
+echo "Running go vet..."
+go vet ./...
+
+echo "Running go test..."
+go test ./...


### PR DESCRIPTION
## Summary
- add a repo-committed pre-commit hook for staged Go changes
- add make targets to install the hook and run the local lint step
- catch formatting, vet, and test failures before CI

## Testing
- bash -n scripts/pre-commit
- make test