### PR TITLE
Harden Vault DB connector configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Flags: `-interval` (default 30s), `-limit` (default 100 per pass), `-once` (sing
 | `ASB_VAULT_TOKEN` | Vault authentication token |
 | `ASB_VAULT_NAMESPACE` | Vault namespace |
 | `ASB_VAULT_ROLE` | Vault DB role name |
+| `ASB_VAULT_ALLOWED_ROLE_SUFFIXES` | Comma-separated allowed Vault DB role suffixes (default `_ro`) |
 | `ASB_VAULT_DSN_TEMPLATE` | DSN template for rendered credentials |
 | `ASB_BROWSER_ORIGIN` | Allowed browser origin (demo) |
 | `ASB_BROWSER_USERNAME` | Browser credential username (demo) |

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -191,41 +191,33 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 		})
 	}
 
-	if vaultAddr := os.Getenv("ASB_VAULT_ADDR"); vaultAddr != "" {
-		role := getenv("ASB_VAULT_ROLE", "analytics_ro")
-		dsnTemplate := os.Getenv("ASB_VAULT_DSN_TEMPLATE")
-		if dsnTemplate != "" {
-			vaultClient := vaultdb.NewHTTPClient(vaultdb.HTTPClientConfig{
-				BaseURL:   vaultAddr,
-				Token:     os.Getenv("ASB_VAULT_TOKEN"),
-				Namespace: os.Getenv("ASB_VAULT_NAMESPACE"),
-			})
-			connectorOptions = append(connectorOptions, resolver.WithVaultDB(vaultdb.NewConnector(vaultdb.Config{
-				Client: vaultClient,
-				RoleDSNs: map[string]string{
-					role: dsnTemplate,
-				},
-			})))
-			mustRegisterToolAndPolicy(ctx, logger, tools, engine, tenantID, core.Tool{
-				TenantID:             tenantID,
-				Tool:                 "db",
-				ManifestHash:         "sha256:dev-db",
-				RuntimeClass:         core.RuntimeClassSidecar,
-				AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
-				AllowedCapabilities:  []string{"db.read"},
-				TrustTags:            []string{"trusted", "db"},
-			}, core.Policy{
-				TenantID:             tenantID,
-				Capability:           "db.read",
-				ResourceKind:         core.ResourceKindDBRole,
-				AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
-				DefaultTTL:           10 * time.Minute,
-				MaxTTL:               30 * time.Minute,
-				ApprovalMode:         core.ApprovalModeNone,
-				RequiredToolTags:     []string{"trusted", "db"},
-				Condition:            `true`,
-			})
-		}
+	vaultConnector, err := newVaultDBConnector()
+	if err != nil {
+		cleanupRuntime()
+		cleanupRepository()
+		return nil, err
+	}
+	if vaultConnector != nil {
+		connectorOptions = append(connectorOptions, resolver.WithVaultDB(vaultConnector))
+		mustRegisterToolAndPolicy(ctx, logger, tools, engine, tenantID, core.Tool{
+			TenantID:             tenantID,
+			Tool:                 "db",
+			ManifestHash:         "sha256:dev-db",
+			RuntimeClass:         core.RuntimeClassSidecar,
+			AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
+			AllowedCapabilities:  []string{"db.read"},
+			TrustTags:            []string{"trusted", "db"},
+		}, core.Policy{
+			TenantID:             tenantID,
+			Capability:           "db.read",
+			ResourceKind:         core.ResourceKindDBRole,
+			AllowedDeliveryModes: []core.DeliveryMode{core.DeliveryModeWrappedSecret},
+			DefaultTTL:           10 * time.Minute,
+			MaxTTL:               30 * time.Minute,
+			ApprovalMode:         core.ApprovalModeNone,
+			RequiredToolTags:     []string{"trusted", "db"},
+			Condition:            `true`,
+		})
 	}
 
 	delegationValidator, err := newDelegationValidator()
@@ -597,6 +589,46 @@ func getenv(key string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func csvEnvOr(key string, fallback []string) []string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return append([]string(nil), fallback...)
+	}
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	if len(values) == 0 {
+		return append([]string(nil), fallback...)
+	}
+	return values
+}
+
+func newVaultDBConnector() (*vaultdb.Connector, error) {
+	vaultAddr := strings.TrimSpace(os.Getenv("ASB_VAULT_ADDR"))
+	dsnTemplate := strings.TrimSpace(os.Getenv("ASB_VAULT_DSN_TEMPLATE"))
+	if vaultAddr == "" || dsnTemplate == "" {
+		return nil, nil
+	}
+
+	role := getenv("ASB_VAULT_ROLE", "analytics_ro")
+	return vaultdb.NewConnector(vaultdb.Config{
+		AllowedRoleSuffixes: csvEnvOr("ASB_VAULT_ALLOWED_ROLE_SUFFIXES", []string{"_ro"}),
+		Client: vaultdb.NewHTTPClient(vaultdb.HTTPClientConfig{
+			BaseURL:   vaultAddr,
+			Token:     os.Getenv("ASB_VAULT_TOKEN"),
+			Namespace: os.Getenv("ASB_VAULT_NAMESPACE"),
+		}),
+		RoleDSNs: map[string]string{
+			role: dsnTemplate,
+		},
+	})
 }
 
 func mustRegisterToolAndPolicy(ctx context.Context, logger *slog.Logger, tools *toolregistry.Registry, engine *policy.Engine, tenantID string, tool core.Tool, pol core.Policy) {

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -94,3 +94,18 @@ func TestNewVaultDBConnectorFailsForInvalidTemplates(t *testing.T) {
 		t.Fatalf("newVaultDBConnector() = %#v, want nil", connector)
 	}
 }
+
+func TestNewVaultDBConnectorFailsForDisallowedRole(t *testing.T) {
+	t.Setenv("ASB_VAULT_ADDR", "https://vault.internal")
+	t.Setenv("ASB_VAULT_DSN_TEMPLATE", "postgres://{{username}}:{{password}}@db.internal/app")
+	t.Setenv("ASB_VAULT_ROLE", "analytics_readonly")
+	t.Setenv("ASB_VAULT_ALLOWED_ROLE_SUFFIXES", "_ro")
+
+	connector, err := newVaultDBConnector()
+	if err == nil || !strings.Contains(err.Error(), "allowed suffixes") {
+		t.Fatalf("newVaultDBConnector() error = %v, want allowed suffix validation error", err)
+	}
+	if connector != nil {
+		t.Fatalf("newVaultDBConnector() = %#v, want nil", connector)
+	}
+}

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -66,3 +66,31 @@ func TestNewApprovalNotifierConfigured(t *testing.T) {
 		t.Fatal("newApprovalNotifier() = nil, want configured notifier")
 	}
 }
+
+func TestNewVaultDBConnectorUsesConfiguredRoleSuffixes(t *testing.T) {
+	t.Setenv("ASB_VAULT_ADDR", "https://vault.internal")
+	t.Setenv("ASB_VAULT_DSN_TEMPLATE", "postgres://{{username}}:{{password}}@db.internal/app")
+	t.Setenv("ASB_VAULT_ROLE", "analytics_readonly")
+	t.Setenv("ASB_VAULT_ALLOWED_ROLE_SUFFIXES", "_readonly,_reader")
+
+	connector, err := newVaultDBConnector()
+	if err != nil {
+		t.Fatalf("newVaultDBConnector() error = %v", err)
+	}
+	if connector == nil {
+		t.Fatal("newVaultDBConnector() = nil, want connector")
+	}
+}
+
+func TestNewVaultDBConnectorFailsForInvalidTemplates(t *testing.T) {
+	t.Setenv("ASB_VAULT_ADDR", "https://vault.internal")
+	t.Setenv("ASB_VAULT_DSN_TEMPLATE", "postgres://db.internal/app")
+
+	connector, err := newVaultDBConnector()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Fatalf("newVaultDBConnector() error = %v, want placeholder validation error", err)
+	}
+	if connector != nil {
+		t.Fatalf("newVaultDBConnector() = %#v, want nil", connector)
+	}
+}

--- a/internal/connectors/vaultdb/client.go
+++ b/internal/connectors/vaultdb/client.go
@@ -11,20 +11,23 @@ import (
 	"time"
 
 	"github.com/evalops/asb/internal/core"
+	"github.com/evalops/service-runtime/resilience"
 )
 
 type HTTPClientConfig struct {
-	BaseURL   string
-	Token     string
-	Namespace string
-	Client    *http.Client
+	BaseURL     string
+	Token       string
+	Namespace   string
+	Client      *http.Client
+	RevokeRetry resilience.RetryConfig
 }
 
 type HTTPClient struct {
-	baseURL   string
-	token     string
-	namespace string
-	client    *http.Client
+	baseURL     string
+	token       string
+	namespace   string
+	client      *http.Client
+	revokeRetry resilience.RetryConfig
 }
 
 func NewHTTPClient(cfg HTTPClientConfig) *HTTPClient {
@@ -32,11 +35,22 @@ func NewHTTPClient(cfg HTTPClientConfig) *HTTPClient {
 	if client == nil {
 		client = http.DefaultClient
 	}
+	revokeRetry := cfg.RevokeRetry
+	if revokeRetry.MaxAttempts == 0 {
+		revokeRetry.MaxAttempts = 4
+	}
+	if revokeRetry.InitialDelay == 0 {
+		revokeRetry.InitialDelay = 100 * time.Millisecond
+	}
+	if revokeRetry.MaxDelay == 0 {
+		revokeRetry.MaxDelay = time.Second
+	}
 	return &HTTPClient{
-		baseURL:   strings.TrimRight(cfg.BaseURL, "/"),
-		token:     cfg.Token,
-		namespace: cfg.Namespace,
-		client:    client,
+		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
+		token:       cfg.Token,
+		namespace:   cfg.Namespace,
+		client:      client,
+		revokeRetry: revokeRetry,
 	}
 }
 
@@ -80,13 +94,19 @@ func (c *HTTPClient) GenerateCredentials(ctx context.Context, role string) (*Lea
 }
 
 func (c *HTTPClient) RevokeLease(ctx context.Context, leaseID string) error {
+	return resilience.Retry(ctx, c.revokeRetry, func(ctx context.Context) error {
+		return c.revokeLeaseOnce(ctx, leaseID)
+	})
+}
+
+func (c *HTTPClient) revokeLeaseOnce(ctx context.Context, leaseID string) error {
 	body, err := json.Marshal(map[string]string{"lease_id": leaseID})
 	if err != nil {
-		return err
+		return resilience.Permanent(err)
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/v1/sys/leases/revoke", bytes.NewReader(body))
 	if err != nil {
-		return err
+		return resilience.Permanent(err)
 	}
 	c.applyHeaders(request)
 	request.Header.Set("Content-Type", "application/json")
@@ -101,7 +121,11 @@ func (c *HTTPClient) RevokeLease(ctx context.Context, leaseID string) error {
 		return err
 	}
 	if response.StatusCode >= 400 {
-		return fmt.Errorf("%w: vault revoke lease returned %d: %s", core.ErrForbidden, response.StatusCode, string(payload))
+		wrapped := fmt.Errorf("%w: vault revoke lease returned %d: %s", core.ErrForbidden, response.StatusCode, string(payload))
+		if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError {
+			return wrapped
+		}
+		return resilience.Permanent(wrapped)
 	}
 	return nil
 }

--- a/internal/connectors/vaultdb/client_test.go
+++ b/internal/connectors/vaultdb/client_test.go
@@ -5,9 +5,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/evalops/asb/internal/connectors/vaultdb"
+	"github.com/evalops/service-runtime/resilience"
 )
 
 func TestHTTPClient_GenerateCredentialsAndRevokeLease(t *testing.T) {
@@ -50,5 +53,71 @@ func TestHTTPClient_GenerateCredentialsAndRevokeLease(t *testing.T) {
 	}
 	if err := client.RevokeLease(context.Background(), lease.LeaseID); err != nil {
 		t.Fatalf("RevokeLease() error = %v", err)
+	}
+}
+
+func TestHTTPClient_RevokeLeaseRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/sys/leases/revoke" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		attempt := attempts.Add(1)
+		if attempt < 3 {
+			http.Error(w, "vault warming up", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := vaultdb.NewHTTPClient(vaultdb.HTTPClientConfig{
+		BaseURL: server.URL,
+		Token:   "vault-token",
+		Client:  server.Client(),
+		RevokeRetry: resilience.RetryConfig{
+			MaxAttempts:  4,
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+		},
+	})
+	if err := client.RevokeLease(context.Background(), "lease-123"); err != nil {
+		t.Fatalf("RevokeLease() error = %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("revoke attempts = %d, want 3", attempts.Load())
+	}
+}
+
+func TestHTTPClient_RevokeLeaseDoesNotRetryPermanentFailures(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/sys/leases/revoke" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		attempts.Add(1)
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := vaultdb.NewHTTPClient(vaultdb.HTTPClientConfig{
+		BaseURL: server.URL,
+		Token:   "vault-token",
+		Client:  server.Client(),
+		RevokeRetry: resilience.RetryConfig{
+			MaxAttempts:  4,
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+		},
+	})
+	if err := client.RevokeLease(context.Background(), "lease-123"); err == nil {
+		t.Fatal("RevokeLease() error = nil, want permanent error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("revoke attempts = %d, want 1", attempts.Load())
 	}
 }

--- a/internal/connectors/vaultdb/connector.go
+++ b/internal/connectors/vaultdb/connector.go
@@ -40,8 +40,14 @@ func NewConnector(cfg Config) (*Connector, error) {
 	if err != nil {
 		return nil, err
 	}
+	allowedRoleSuffixes := normalizeRoleSuffixes(cfg.AllowedRoleSuffixes)
+	for role := range roleDSNs {
+		if !roleHasAllowedSuffix(role, allowedRoleSuffixes) {
+			return nil, fmt.Errorf("%w: db role %q must match one of the allowed suffixes %v", core.ErrInvalidRequest, role, allowedRoleSuffixes)
+		}
+	}
 	return &Connector{
-		allowedRoleSuffixes: normalizeRoleSuffixes(cfg.AllowedRoleSuffixes),
+		allowedRoleSuffixes: allowedRoleSuffixes,
 		client:              cfg.Client,
 		roleDSNs:            roleDSNs,
 	}, nil
@@ -157,7 +163,11 @@ func (c *Connector) validateRole(kind core.ResourceKind, role string) error {
 }
 
 func (c *Connector) allowedRole(role string) bool {
-	for _, suffix := range c.allowedRoleSuffixes {
+	return roleHasAllowedSuffix(role, c.allowedRoleSuffixes)
+}
+
+func roleHasAllowedSuffix(role string, allowedRoleSuffixes []string) bool {
+	for _, suffix := range allowedRoleSuffixes {
 		if strings.HasSuffix(role, suffix) {
 			return true
 		}
@@ -185,8 +195,8 @@ func renderDSN(renderPattern string, lease *LeaseCredentials) (string, error) {
 	}
 	var builder strings.Builder
 	if err := tpl.Execute(&builder, map[string]string{
-		"username": url.QueryEscape(lease.Username),
-		"password": url.QueryEscape(lease.Password),
+		"username": url.PathEscape(lease.Username),
+		"password": url.PathEscape(lease.Password),
 	}); err != nil {
 		return "", fmt.Errorf("%w: render dsn template: %v", core.ErrInvalidRequest, err)
 	}

--- a/internal/connectors/vaultdb/connector.go
+++ b/internal/connectors/vaultdb/connector.go
@@ -3,6 +3,7 @@ package vaultdb
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"text/template"
 	"time"
@@ -23,20 +24,61 @@ type Client interface {
 }
 
 type Config struct {
-	Client   Client
-	RoleDSNs map[string]string
+	AllowedRoleSuffixes []string
+	Client              Client
+	RoleDSNs            map[string]string
 }
 
 type Connector struct {
-	client   Client
-	roleDSNs map[string]string
+	allowedRoleSuffixes []string
+	client              Client
+	roleDSNs            map[string]string
 }
 
-func NewConnector(cfg Config) *Connector {
-	return &Connector{
-		client:   cfg.Client,
-		roleDSNs: cfg.RoleDSNs,
+func NewConnector(cfg Config) (*Connector, error) {
+	roleDSNs, err := normalizeRoleDSNs(cfg.RoleDSNs)
+	if err != nil {
+		return nil, err
 	}
+	return &Connector{
+		allowedRoleSuffixes: normalizeRoleSuffixes(cfg.AllowedRoleSuffixes),
+		client:              cfg.Client,
+		roleDSNs:            roleDSNs,
+	}, nil
+}
+
+func normalizeRoleDSNs(roleDSNs map[string]string) (map[string]string, error) {
+	if len(roleDSNs) == 0 {
+		return map[string]string{}, nil
+	}
+
+	normalized := make(map[string]string, len(roleDSNs))
+	for role, pattern := range roleDSNs {
+		renderPattern, err := normalizeDSNTemplate(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("%w: role %q: %v", core.ErrInvalidRequest, role, err)
+		}
+		normalized[role] = renderPattern
+	}
+	return normalized, nil
+}
+
+func normalizeRoleSuffixes(suffixes []string) []string {
+	if len(suffixes) == 0 {
+		return []string{"_ro"}
+	}
+
+	normalized := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		trimmed := strings.TrimSpace(suffix)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	if len(normalized) == 0 {
+		return []string{"_ro"}
+	}
+	return normalized
 }
 
 func (c *Connector) Kind() string {
@@ -48,16 +90,7 @@ func (c *Connector) ValidateResource(_ context.Context, req core.ValidateResourc
 	if err != nil {
 		return err
 	}
-	if resource.Kind != core.ResourceKindDBRole {
-		return fmt.Errorf("%w: vault db connector only supports db roles", core.ErrInvalidRequest)
-	}
-	if !strings.HasSuffix(resource.Name, "_ro") {
-		return fmt.Errorf("%w: v1 only allows read-only db roles", core.ErrForbidden)
-	}
-	if _, ok := c.roleDSNs[resource.Name]; !ok {
-		return fmt.Errorf("%w: no DSN template configured for %q", core.ErrNotFound, resource.Name)
-	}
-	return nil
+	return c.validateRole(resource.Kind, resource.Name)
 }
 
 func (c *Connector) Issue(ctx context.Context, req core.IssueRequest) (*core.IssuedArtifact, error) {
@@ -69,6 +102,9 @@ func (c *Connector) Issue(ctx context.Context, req core.IssueRequest) (*core.Iss
 	}
 	if req.Grant.DeliveryMode != core.DeliveryModeWrappedSecret {
 		return nil, fmt.Errorf("%w: vault db connector only supports wrapped secret delivery", core.ErrInvalidRequest)
+	}
+	if err := c.validateRole(req.Resource.Kind, req.Resource.Name); err != nil {
+		return nil, err
 	}
 
 	lease, err := c.client.GenerateCredentials(ctx, req.Resource.Name)
@@ -107,17 +143,50 @@ func (c *Connector) Revoke(ctx context.Context, req core.RevokeRequest) error {
 	return c.client.RevokeLease(ctx, leaseID)
 }
 
-func renderDSN(pattern string, lease *LeaseCredentials) (string, error) {
-	pattern = strings.ReplaceAll(pattern, "{{username}}", "{{.username}}")
-	pattern = strings.ReplaceAll(pattern, "{{password}}", "{{.password}}")
-	tpl, err := template.New("dsn").Parse(pattern)
+func (c *Connector) validateRole(kind core.ResourceKind, role string) error {
+	if kind != core.ResourceKindDBRole {
+		return fmt.Errorf("%w: vault db connector only supports db roles", core.ErrInvalidRequest)
+	}
+	if !c.allowedRole(role) {
+		return fmt.Errorf("%w: db role %q must match one of the allowed suffixes %v", core.ErrForbidden, role, c.allowedRoleSuffixes)
+	}
+	if _, ok := c.roleDSNs[role]; !ok {
+		return fmt.Errorf("%w: no DSN template configured for %q", core.ErrNotFound, role)
+	}
+	return nil
+}
+
+func (c *Connector) allowedRole(role string) bool {
+	for _, suffix := range c.allowedRoleSuffixes {
+		if strings.HasSuffix(role, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDSNTemplate(pattern string) (string, error) {
+	trimmed := strings.TrimSpace(pattern)
+	if !strings.Contains(trimmed, "{{username}}") || !strings.Contains(trimmed, "{{password}}") {
+		return "", fmt.Errorf("dsn template must include {{username}} and {{password}} placeholders")
+	}
+	trimmed = strings.ReplaceAll(trimmed, "{{username}}", "{{.username}}")
+	trimmed = strings.ReplaceAll(trimmed, "{{password}}", "{{.password}}")
+	if _, err := template.New("dsn").Parse(trimmed); err != nil {
+		return "", fmt.Errorf("parse dsn template: %v", err)
+	}
+	return trimmed, nil
+}
+
+func renderDSN(renderPattern string, lease *LeaseCredentials) (string, error) {
+	tpl, err := template.New("dsn").Parse(renderPattern)
 	if err != nil {
 		return "", fmt.Errorf("%w: parse dsn template: %v", core.ErrInvalidRequest, err)
 	}
 	var builder strings.Builder
 	if err := tpl.Execute(&builder, map[string]string{
-		"username": lease.Username,
-		"password": lease.Password,
+		"username": url.QueryEscape(lease.Username),
+		"password": url.QueryEscape(lease.Password),
 	}); err != nil {
 		return "", fmt.Errorf("%w: render dsn template: %v", core.ErrInvalidRequest, err)
 	}

--- a/internal/connectors/vaultdb/connector_test.go
+++ b/internal/connectors/vaultdb/connector_test.go
@@ -2,6 +2,7 @@ package vaultdb_test
 
 import (
 	"context"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -87,6 +88,20 @@ func TestNewConnectorRejectsUnsafeDSNTemplates(t *testing.T) {
 	}
 }
 
+func TestNewConnectorRejectsRolesOutsideAllowedSuffixes(t *testing.T) {
+	t.Parallel()
+
+	_, err := vaultdb.NewConnector(vaultdb.Config{
+		AllowedRoleSuffixes: []string{"_ro"},
+		RoleDSNs: map[string]string{
+			"analytics_readonly": "postgres://{{username}}:{{password}}@db.internal/app",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "allowed suffixes") {
+		t.Fatalf("NewConnector() error = %v, want allowed suffix validation error", err)
+	}
+}
+
 func TestConnectorHonorsConfiguredRoleSuffixes(t *testing.T) {
 	t.Parallel()
 
@@ -126,6 +141,58 @@ func TestConnectorHonorsConfiguredRoleSuffixes(t *testing.T) {
 		},
 	}); err == nil || !strings.Contains(err.Error(), "allowed suffixes") {
 		t.Fatalf("Issue() error = %v, want suffix validation error", err)
+	}
+}
+
+func TestConnectorIssueEscapesUserinfoWithPercentEncoding(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeVaultClient{
+		lease: &vaultdb.LeaseCredentials{
+			Username:      "vault user",
+			Password:      "vault secret",
+			LeaseID:       "database/creds/analytics_ro/spacey",
+			LeaseDuration: 10 * time.Minute,
+		},
+	}
+	connector, err := vaultdb.NewConnector(vaultdb.Config{
+		Client: client,
+		RoleDSNs: map[string]string{
+			"analytics_ro": "postgres://{{username}}:{{password}}@db.internal:5432/analytics",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	issued, err := connector.Issue(context.Background(), core.IssueRequest{
+		Session: &core.Session{ID: "sess_db", TenantID: "t_acme"},
+		Grant: &core.Grant{
+			ID:           "gr_db",
+			DeliveryMode: core.DeliveryModeWrappedSecret,
+		},
+		Resource: core.ResourceDescriptor{
+			Kind: core.ResourceKindDBRole,
+			Name: "analytics_ro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if strings.Contains(issued.SecretData["dsn"], "+") {
+		t.Fatalf("dsn = %q, want spaces percent-encoded in userinfo", issued.SecretData["dsn"])
+	}
+
+	parsed, err := url.Parse(issued.SecretData["dsn"])
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	password, ok := parsed.User.Password()
+	if !ok {
+		t.Fatalf("parsed dsn = %q, want password present", issued.SecretData["dsn"])
+	}
+	if parsed.User.Username() != client.lease.Username || password != client.lease.Password {
+		t.Fatalf("parsed credentials = %q/%q, want %q/%q", parsed.User.Username(), password, client.lease.Username, client.lease.Password)
 	}
 }
 

--- a/internal/connectors/vaultdb/connector_test.go
+++ b/internal/connectors/vaultdb/connector_test.go
@@ -2,6 +2,7 @@ package vaultdb_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,17 +16,20 @@ func TestConnector_IssueAndRevokeDynamicCredentials(t *testing.T) {
 	client := &fakeVaultClient{
 		lease: &vaultdb.LeaseCredentials{
 			Username:      "v-token-user",
-			Password:      "secret",
+			Password:      "secret:/?#[]@",
 			LeaseID:       "database/creds/analytics_ro/123",
 			LeaseDuration: 10 * time.Minute,
 		},
 	}
-	connector := vaultdb.NewConnector(vaultdb.Config{
+	connector, err := vaultdb.NewConnector(vaultdb.Config{
 		Client: client,
 		RoleDSNs: map[string]string{
 			"analytics_ro": "postgres://{{username}}:{{password}}@db.internal:5432/analytics?sslmode=require",
 		},
 	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
 
 	issued, err := connector.Issue(context.Background(), core.IssueRequest{
 		Session: &core.Session{ID: "sess_db", TenantID: "t_acme"},
@@ -48,6 +52,9 @@ func TestConnector_IssueAndRevokeDynamicCredentials(t *testing.T) {
 	if issued.SecretData["dsn"] == "" || issued.Metadata["lease_id"] == "" {
 		t.Fatalf("issued artifact = %#v, want dsn and lease id", issued)
 	}
+	if strings.Contains(issued.SecretData["dsn"], "secret:/?#[]@") {
+		t.Fatalf("dsn = %q, want escaped credentials", issued.SecretData["dsn"])
+	}
 
 	if err := connector.Revoke(context.Background(), core.RevokeRequest{
 		Session: &core.Session{ID: "sess_db", TenantID: "t_acme"},
@@ -64,6 +71,61 @@ func TestConnector_IssueAndRevokeDynamicCredentials(t *testing.T) {
 	}
 	if client.revokedLeaseID != "database/creds/analytics_ro/123" {
 		t.Fatalf("revoked lease = %q, want expected lease", client.revokedLeaseID)
+	}
+}
+
+func TestNewConnectorRejectsUnsafeDSNTemplates(t *testing.T) {
+	t.Parallel()
+
+	_, err := vaultdb.NewConnector(vaultdb.Config{
+		RoleDSNs: map[string]string{
+			"analytics_ro": "postgres://db.internal:5432/analytics",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Fatalf("NewConnector() error = %v, want placeholder validation error", err)
+	}
+}
+
+func TestConnectorHonorsConfiguredRoleSuffixes(t *testing.T) {
+	t.Parallel()
+
+	connector, err := vaultdb.NewConnector(vaultdb.Config{
+		AllowedRoleSuffixes: []string{"_readonly"},
+		Client: &fakeVaultClient{
+			lease: &vaultdb.LeaseCredentials{
+				Username:      "dyn-user",
+				Password:      "dyn-pass",
+				LeaseID:       "lease-1",
+				LeaseDuration: time.Minute,
+			},
+		},
+		RoleDSNs: map[string]string{
+			"analytics_readonly": "postgres://{{username}}:{{password}}@db.internal/app",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	if err := connector.ValidateResource(context.Background(), core.ValidateResourceRequest{
+		ResourceRef: "dbrole:analytics_readonly",
+	}); err != nil {
+		t.Fatalf("ValidateResource() error = %v", err)
+	}
+
+	if _, err := connector.Issue(context.Background(), core.IssueRequest{
+		Session: &core.Session{ID: "sess_db", TenantID: "t_acme"},
+		Grant: &core.Grant{
+			ID:           "gr_db",
+			DeliveryMode: core.DeliveryModeWrappedSecret,
+		},
+		Resource: core.ResourceDescriptor{
+			Kind: core.ResourceKindDBRole,
+			Name: "analytics_readwrite",
+		},
+	}); err == nil || !strings.Contains(err.Error(), "allowed suffixes") {
+		t.Fatalf("Issue() error = %v, want suffix validation error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate Vault DSN templates at connector construction time and escape credential values during rendering
- make allowed Vault DB role suffixes configurable and enforce them in both resource validation and issue paths
- retry transient Vault lease revocation failures with backoff and add regression coverage for the new hardening paths

## Testing
- go test ./internal/connectors/vaultdb ./internal/bootstrap -count=1
- go test ./... -count=1

## Notes
- repo-wide golangci-lint currently reports unrelated pre-existing issues in untouched files on main (`internal/api/httpapi/server.go`, `internal/connectors/github/*`, `internal/crypto/sessionjwt/manager.go`, `internal/app/cleanup.go`)

Refs EvalOps/asb#13