### PR TITLE
Harden GitHub connector error handling

### DIFF
--- a/internal/api/connectapi/server.go
+++ b/internal/api/connectapi/server.go
@@ -221,10 +221,14 @@ func connectError(err error) error {
 		code = connect.CodeUnimplemented
 	case errors.Is(err, core.ErrUnauthorized):
 		code = connect.CodeUnauthenticated
+	case errors.Is(err, core.ErrRateLimited):
+		code = connect.CodeResourceExhausted
 	case errors.Is(err, core.ErrForbidden):
 		code = connect.CodePermissionDenied
 	case errors.Is(err, core.ErrNotFound):
 		code = connect.CodeNotFound
+	case errors.Is(err, core.ErrUnavailable):
+		code = connect.CodeUnavailable
 	case errors.Is(err, core.ErrResourceBudgetExceeded):
 		code = connect.CodeResourceExhausted
 	}

--- a/internal/api/connectapi/server_test.go
+++ b/internal/api/connectapi/server_test.go
@@ -80,6 +80,33 @@ func TestServer_CreateSessionAndExecuteProxy(t *testing.T) {
 	}
 }
 
+func TestServer_ExecuteProxyUnavailableMapsToConnectUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	path, handler := connectapi.NewHandler(&stubService{
+		executeGitHubProxy: func(context.Context, *core.ExecuteGitHubProxyRequest) (*core.ExecuteGitHubProxyResponse, error) {
+			return nil, core.ErrUnavailable
+		},
+	})
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := asbv1connect.NewBrokerServiceClient(server.Client(), server.URL)
+	_, err := client.ExecuteGitHubProxy(context.Background(), connect.NewRequest(&asbv1.ExecuteGitHubProxyRequest{
+		ProxyHandle: "ph_456",
+		Operation:   "repository_metadata",
+	}))
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("error = %v, want connect error", err)
+	}
+	if connectErr.Code() != connect.CodeUnavailable {
+		t.Fatalf("connect code = %v, want %v", connectErr.Code(), connect.CodeUnavailable)
+	}
+}
+
 func TestServer_MapsCoreErrorsToConnectCodes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -382,10 +382,14 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusNotImplemented
 	case errors.Is(err, core.ErrUnauthorized):
 		status = http.StatusUnauthorized
+	case errors.Is(err, core.ErrRateLimited):
+		status = http.StatusTooManyRequests
 	case errors.Is(err, core.ErrForbidden):
 		status = http.StatusForbidden
 	case errors.Is(err, core.ErrNotFound):
 		status = http.StatusNotFound
+	case errors.Is(err, core.ErrUnavailable):
+		status = http.StatusServiceUnavailable
 	}
 	writeJSON(w, status, map[string]string{"error": err.Error()})
 }

--- a/internal/api/httpapi/server_test.go
+++ b/internal/api/httpapi/server_test.go
@@ -401,6 +401,30 @@ func TestServer_RegisterBrowserRelayAndUnwrap(t *testing.T) {
 	}
 }
 
+func TestServer_ExecuteGitHubProxyRateLimited(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{
+		executeGitHubProxy: func(context.Context, *core.ExecuteGitHubProxyRequest) (*core.ExecuteGitHubProxyResponse, error) {
+			return nil, core.ErrRateLimited
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/proxy/github/rest", bytes.NewBufferString(`{
+		"proxy_handle":"ph_456",
+		"operation":"repository_metadata",
+		"params":{}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	httpapi.NewServer(svc).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
+	}
+}
+
 type stubService struct {
 	createSession        func(context.Context, *core.CreateSessionRequest) (*core.CreateSessionResponse, error)
 	requestGrant         func(context.Context, *core.RequestGrantRequest) (*core.RequestGrantResponse, error)

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -385,6 +385,10 @@ func newDelegationValidator() (core.DelegationValidator, error) {
 
 func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
 	var tokenSource githubconnector.RepoTokenSource
+	var staticTokenSource githubconnector.RepoTokenSource
+	if token := os.Getenv("ASB_GITHUB_TOKEN"); token != "" {
+		staticTokenSource = githubconnector.StaticTokenSource(token)
+	}
 
 	if appIDRaw := os.Getenv("ASB_GITHUB_APP_ID"); appIDRaw != "" && os.Getenv("ASB_GITHUB_APP_PRIVATE_KEY_FILE") != "" {
 		appID, err := strconv.ParseInt(appIDRaw, 10, 64)
@@ -410,8 +414,9 @@ func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if token := os.Getenv("ASB_GITHUB_TOKEN"); token != "" {
-		tokenSource = githubconnector.StaticTokenSource(token)
+		tokenSource = githubconnector.FallbackTokenSource(tokenSource, staticTokenSource)
+	} else if staticTokenSource != nil {
+		tokenSource = staticTokenSource
 	}
 
 	if tokenSource == nil {

--- a/internal/connectors/github/app_token_source.go
+++ b/internal/connectors/github/app_token_source.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/evalops/asb/internal/core"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type AppTokenSourceConfig struct {
@@ -83,7 +83,7 @@ func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo st
 	s.mu.Lock()
 	installationID, ok := s.repoInstallations[repoKey]
 	if ok {
-		if cached, ok := s.installationCache[installationID]; ok && cached.expiresAt.After(s.now().Add(1*time.Minute)) {
+		if cached, ok := s.installationCache[installationID]; ok && cached.expiresAt.After(s.now().Add(5*time.Minute)) {
 			token := cached.token
 			s.mu.Unlock()
 			return token, nil
@@ -147,13 +147,15 @@ func (s *AppTokenSource) lookupInstallationID(ctx context.Context, owner string,
 	if err != nil {
 		return 0, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return 0, err
 	}
 	if response.StatusCode >= 400 {
-		return 0, fmt.Errorf("%w: lookup GitHub installation returned %d: %s", core.ErrForbidden, response.StatusCode, string(body))
+		return 0, classifyGitHubAPIError(response, body, "lookup GitHub installation")
 	}
 	var payload struct {
 		ID int64 `json:"id"`
@@ -184,13 +186,15 @@ func (s *AppTokenSource) createInstallationToken(ctx context.Context, installati
 	if err != nil {
 		return "", time.Time{}, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", time.Time{}, err
 	}
 	if response.StatusCode >= 400 {
-		return "", time.Time{}, fmt.Errorf("%w: create GitHub installation token returned %d: %s", core.ErrForbidden, response.StatusCode, string(body))
+		return "", time.Time{}, classifyGitHubAPIError(response, body, "create GitHub installation token")
 	}
 	var payload struct {
 		Token     string    `json:"token"`

--- a/internal/connectors/github/app_token_source_test.go
+++ b/internal/connectors/github/app_token_source_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/evalops/asb/internal/connectors/github"
+	"github.com/evalops/asb/internal/core"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T) {
@@ -74,6 +76,112 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 	}
 	if installationLookups != 1 || tokenRequests != 1 {
 		t.Fatalf("lookups/requests = %d/%d, want 1/1", installationLookups, tokenRequests)
+	}
+}
+
+func TestAppTokenSource_TokenForRepoRefreshesWhenTokenNearExpiry(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	currentTime := now
+	tokenRequests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widgets/installation":
+			_, _ = w.Write([]byte(`{"id":987}`))
+		case "/app/installations/987/access_tokens":
+			tokenRequests++
+			tokenValue := "inst-token-1"
+			if tokenRequests > 1 {
+				tokenValue = "inst-token-2"
+			}
+			_, _ = w.Write([]byte(`{"token":"` + tokenValue + `","expires_at":"` + now.Add(6*time.Minute).Format(time.RFC3339) + `"}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	source, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Now: func() time.Time {
+			return currentTime
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() error = %v", err)
+	}
+
+	firstToken, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	if err != nil {
+		t.Fatalf("TokenForRepo() first error = %v", err)
+	}
+	currentTime = now.Add(2 * time.Minute)
+	secondToken, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	if err != nil {
+		t.Fatalf("TokenForRepo() second error = %v", err)
+	}
+	if firstToken == secondToken {
+		t.Fatalf("expected pre-refresh to mint a new token, got %q", secondToken)
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("token requests = %d, want 2", tokenRequests)
+	}
+}
+
+func TestAppTokenSource_ClassifiesGitHubErrors(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	tests := []struct {
+		name       string
+		statusCode int
+		headers    map[string]string
+		wantErr    error
+	}{
+		{name: "not found", statusCode: http.StatusNotFound, wantErr: core.ErrNotFound},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, headers: map[string]string{"Retry-After": "60"}, wantErr: core.ErrRateLimited},
+		{name: "unavailable", statusCode: http.StatusBadGateway, wantErr: core.ErrUnavailable},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for key, value := range tc.headers {
+					w.Header().Set(key, value)
+				}
+				http.Error(w, tc.name, tc.statusCode)
+			}))
+			defer server.Close()
+
+			source, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+				AppID:      123,
+				PrivateKey: privateKey,
+				BaseURL:    server.URL,
+				Client:     server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewAppTokenSource() error = %v", err)
+			}
+
+			_, err = source.TokenForRepo(context.Background(), "acme", "widgets")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("TokenForRepo() error = %v, want %v", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/connectors/github/errors.go
+++ b/internal/connectors/github/errors.go
@@ -1,0 +1,29 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/evalops/asb/internal/core"
+)
+
+func classifyGitHubAPIError(response *http.Response, body []byte, action string) error {
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = http.StatusText(response.StatusCode)
+	}
+
+	switch {
+	case response.StatusCode == http.StatusUnauthorized:
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrUnauthorized, action, response.StatusCode, message)
+	case response.StatusCode == http.StatusTooManyRequests || response.Header.Get("Retry-After") != "" || response.Header.Get("X-RateLimit-Remaining") == "0":
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrRateLimited, action, response.StatusCode, message)
+	case response.StatusCode == http.StatusNotFound:
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrNotFound, action, response.StatusCode, message)
+	case response.StatusCode >= http.StatusInternalServerError:
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrUnavailable, action, response.StatusCode, message)
+	default:
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrForbidden, action, response.StatusCode, message)
+	}
+}

--- a/internal/connectors/github/executor.go
+++ b/internal/connectors/github/executor.go
@@ -76,13 +76,15 @@ func (e *HTTPExecutor) Execute(ctx context.Context, artifact *core.Artifact, ope
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
 	if response.StatusCode >= 400 {
-		return nil, fmt.Errorf("%w: github api returned %d: %s", core.ErrForbidden, response.StatusCode, string(body))
+		return nil, classifyGitHubAPIError(response, body, "github api request")
 	}
 	return body, nil
 }

--- a/internal/connectors/github/executor_test.go
+++ b/internal/connectors/github/executor_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,5 +48,49 @@ func TestHTTPExecutor_ExecutePullRequestFiles(t *testing.T) {
 	}
 	if string(payload) != `{"files":[{"filename":"main.go"}]}` {
 		t.Fatalf("payload = %s, want expected github json", string(payload))
+	}
+}
+
+func TestHTTPExecutor_ClassifiesGitHubAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		headers    map[string]string
+		wantErr    error
+	}{
+		{name: "not found", statusCode: http.StatusNotFound, wantErr: core.ErrNotFound},
+		{name: "permission denied", statusCode: http.StatusForbidden, wantErr: core.ErrForbidden},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, headers: map[string]string{"Retry-After": "60"}, wantErr: core.ErrRateLimited},
+		{name: "unavailable", statusCode: http.StatusBadGateway, wantErr: core.ErrUnavailable},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for key, value := range tc.headers {
+					w.Header().Set(key, value)
+				}
+				http.Error(w, tc.name, tc.statusCode)
+			}))
+			defer server.Close()
+
+			executor := github.NewHTTPExecutor(github.ExecutorConfig{
+				BaseURL:     server.URL,
+				Client:      server.Client(),
+				TokenSource: github.StaticTokenSource("test-token"),
+			})
+			_, err := executor.Execute(context.Background(), &core.Artifact{
+				Metadata: map[string]string{
+					"resource_ref": "github:repo:acme/widgets",
+				},
+			}, "repository_metadata", nil)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Execute() error = %v, want %v", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/connectors/github/token_source.go
+++ b/internal/connectors/github/token_source.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evalops/asb/internal/core"
+)
+
+func FallbackTokenSource(primary RepoTokenSource, fallback RepoTokenSource) RepoTokenSource {
+	if primary == nil {
+		return fallback
+	}
+	if fallback == nil {
+		return primary
+	}
+	return fallbackTokenSource{
+		primary:  primary,
+		fallback: fallback,
+	}
+}
+
+type fallbackTokenSource struct {
+	primary  RepoTokenSource
+	fallback RepoTokenSource
+}
+
+func (s fallbackTokenSource) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
+	token, err := s.primary.TokenForRepo(ctx, owner, repo)
+	if err == nil {
+		return token, nil
+	}
+
+	fallbackToken, fallbackErr := s.fallback.TokenForRepo(ctx, owner, repo)
+	if fallbackErr != nil {
+		return "", fmt.Errorf("%w: primary token source failed: %v; fallback token source failed: %v", core.ErrUnauthorized, err, fallbackErr)
+	}
+	return fallbackToken, nil
+}

--- a/internal/connectors/github/token_source_test.go
+++ b/internal/connectors/github/token_source_test.go
@@ -1,0 +1,36 @@
+package github_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/evalops/asb/internal/connectors/github"
+)
+
+func TestFallbackTokenSourceUsesFallbackOnPrimaryFailure(t *testing.T) {
+	t.Parallel()
+
+	source := github.FallbackTokenSource(
+		repoTokenSourceFunc(func(context.Context, string, string) (string, error) {
+			return "", errors.New("app token exchange failed")
+		}),
+		repoTokenSourceFunc(func(context.Context, string, string) (string, error) {
+			return "static-token", nil
+		}),
+	)
+
+	token, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	if err != nil {
+		t.Fatalf("TokenForRepo() error = %v", err)
+	}
+	if token != "static-token" {
+		t.Fatalf("token = %q, want static-token", token)
+	}
+}
+
+type repoTokenSourceFunc func(context.Context, string, string) (string, error)
+
+func (fn repoTokenSourceFunc) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
+	return fn(ctx, owner, repo)
+}

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -5,7 +5,9 @@ import "errors"
 var (
 	ErrInvalidRequest             = errors.New("invalid request")
 	ErrNotFound                   = errors.New("not found")
+	ErrRateLimited                = errors.New("rate limited")
 	ErrUnauthorized               = errors.New("unauthorized")
+	ErrUnavailable                = errors.New("unavailable")
 	ErrForbidden                  = errors.New("forbidden")
 	ErrDeliveryModeNotImplemented = errors.New("delivery mode not implemented")
 	ErrResourceBudgetExceeded     = errors.New("resource budget exceeded")


### PR DESCRIPTION
## Summary
- classify GitHub API failures into not found, rate limited, unavailable, unauthorized, and forbidden broker errors
- refresh GitHub App installation tokens when less than five minutes remain and allow fallback to a static token when app token exchange fails
- map the new broker errors through both HTTP and Connect APIs with regression coverage

## Testing
- go test ./internal/connectors/github ./internal/api/httpapi ./internal/api/connectapi ./internal/bootstrap -count=1
- go test ./... -count=1

## Notes
- repo-wide golangci-lint still reports pre-existing issues in untouched files on `main` (`internal/api/httpapi/server.go`, `internal/connectors/vaultdb/client.go`, `internal/crypto/sessionjwt/manager.go`, `internal/api/connectapi/server.go`, `internal/app/cleanup.go`)

Refs EvalOps/asb#12