### PR TITLE
Add OIDC workload attestation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,16 +222,22 @@ Flags: `-interval` (default 30s), `-limit` (default 100 per pass), `-once` (sing
 
 ### Required for API startup
 
+Configure at least one attestation verifier:
+
 | Variable | Purpose |
 |----------|---------|
 | `ASB_K8S_ISSUER` | Expected issuer in Kubernetes SA JWTs |
-| `ASB_K8S_PUBLIC_KEY_FILE` | Public key for JWT verification |
+| `ASB_K8S_PUBLIC_KEY_FILE` | Public key for Kubernetes SA JWT verification |
+| `ASB_OIDC_ISSUER` | Expected issuer for generic OIDC workload JWTs |
+| `ASB_OIDC_PUBLIC_KEY_FILE` | Public key for OIDC workload JWT verification |
 
 ### Optional
 
 | Variable | Purpose |
 |----------|---------|
 | `ASB_K8S_AUDIENCE` | Expected audience claim |
+| `ASB_OIDC_AUDIENCE` | Expected audience claim for OIDC workload JWTs (default `asb-control-plane`) |
+| `ASB_OIDC_ALLOWED_SUBJECT_PREFIXES` | Comma-separated allowed OIDC subject prefixes |
 | `ASB_ADDR` | Listen address (default `:8080`) |
 | `ASB_DEV_TENANT_ID` | Tenant ID for local development |
 | `ASB_POSTGRES_DSN` | Enables Postgres repository |
@@ -294,6 +300,16 @@ make run-worker    # start the cleanup worker
 export ASB_K8S_ISSUER="https://cluster.example"
 export ASB_K8S_PUBLIC_KEY_FILE="./dev/keys/k8s-sa.pub"
 export ASB_GITHUB_TOKEN="ghp_..."
+make run-api
+```
+
+For generic OIDC workload identity, configure the OIDC verifier instead:
+
+```bash
+export ASB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+export ASB_OIDC_PUBLIC_KEY_FILE="./dev/keys/github-actions.pub"
+export ASB_OIDC_AUDIENCE="asb-control-plane"
+export ASB_OIDC_ALLOWED_SUBJECT_PREFIXES="repo:evalops/"
 make run-api
 ```
 

--- a/internal/api/connectapi/server.go
+++ b/internal/api/connectapi/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evalops/asb/internal/core"
 	asbv1 "github.com/evalops/asb/proto/asb/v1"
 	"github.com/evalops/asb/proto/asb/v1/asbv1connect"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -227,11 +226,4 @@ func connectError(err error) error {
 		code = connect.CodeResourceExhausted
 	}
 	return connect.NewError(code, err)
-}
-
-func structFromMap(values map[string]any) (*structpb.Struct, error) {
-	if values == nil {
-		return nil, nil
-	}
-	return structpb.NewStruct(values)
 }

--- a/internal/api/connectapi/server_test.go
+++ b/internal/api/connectapi/server_test.go
@@ -109,6 +109,44 @@ func TestServer_MapsCoreErrorsToConnectCodes(t *testing.T) {
 	}
 }
 
+func TestServer_CreateSessionAcceptsOIDCAttestationKind(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubService{
+		createSession: func(_ context.Context, req *core.CreateSessionRequest) (*core.CreateSessionResponse, error) {
+			if req.Attestation == nil || req.Attestation.Kind != core.AttestationKindOIDCJWT {
+				t.Fatalf("unexpected attestation = %#v", req.Attestation)
+			}
+			return &core.CreateSessionResponse{
+				SessionID:    "sess_oidc",
+				SessionToken: "eyJ.oidc",
+				ExpiresAt:    time.Date(2026, 4, 15, 6, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+
+	path, handler := connectapi.NewHandler(svc)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := asbv1connect.NewBrokerServiceClient(server.Client(), server.URL)
+	resp, err := client.CreateSession(context.Background(), connect.NewRequest(&asbv1.CreateSessionRequest{
+		TenantId:    "t_acme",
+		AgentId:     "agent_ci",
+		RunId:       "run_oidc",
+		ToolContext: []string{"github"},
+		Attestation: &asbv1.Attestation{Kind: "oidc_jwt", Token: "jwt"},
+	}))
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	if resp.Msg.GetSessionId() != "sess_oidc" {
+		t.Fatalf("session_id = %q, want sess_oidc", resp.Msg.GetSessionId())
+	}
+}
+
 type stubService struct {
 	createSession        func(context.Context, *core.CreateSessionRequest) (*core.CreateSessionResponse, error)
 	requestGrant         func(context.Context, *core.RequestGrantRequest) (*core.RequestGrantResponse, error)

--- a/internal/authn/oidc/verifier.go
+++ b/internal/authn/oidc/verifier.go
@@ -89,9 +89,6 @@ func (v *Verifier) Verify(ctx context.Context, in *core.Attestation) (*core.Work
 	copyStringClaim(identity.Attributes, claims, "workflow")
 	copyNumericClaim(identity.Attributes, claims, "run_attempt")
 	copyNumericClaim(identity.Attributes, claims, "run_id")
-	if len(identity.Attributes) == 0 {
-		identity.Attributes = map[string]string{}
-	}
 	return identity, nil
 }
 

--- a/internal/authn/oidc/verifier.go
+++ b/internal/authn/oidc/verifier.go
@@ -1,0 +1,146 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/evalops/asb/internal/core"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type Keyfunc func(ctx context.Context, token *jwt.Token) (any, error)
+
+type Config struct {
+	Issuer                 string
+	Audience               string
+	Keyfunc                Keyfunc
+	AllowedSubjectPrefixes []string
+}
+
+type Verifier struct {
+	issuer                 string
+	audience               string
+	keyfunc                Keyfunc
+	allowedSubjectPrefixes []string
+}
+
+func NewVerifier(cfg Config) (*Verifier, error) {
+	if cfg.Issuer == "" || cfg.Audience == "" || cfg.Keyfunc == nil {
+		return nil, fmt.Errorf("%w: issuer, audience, and keyfunc are required", core.ErrInvalidRequest)
+	}
+	prefixes := make([]string, 0, len(cfg.AllowedSubjectPrefixes))
+	for _, prefix := range cfg.AllowedSubjectPrefixes {
+		if trimmed := strings.TrimSpace(prefix); trimmed != "" {
+			prefixes = append(prefixes, trimmed)
+		}
+	}
+	return &Verifier{
+		issuer:                 cfg.Issuer,
+		audience:               cfg.Audience,
+		keyfunc:                cfg.Keyfunc,
+		allowedSubjectPrefixes: prefixes,
+	}, nil
+}
+
+func (v *Verifier) Verify(ctx context.Context, in *core.Attestation) (*core.WorkloadIdentity, error) {
+	if in == nil || in.Kind != core.AttestationKindOIDCJWT || strings.TrimSpace(in.Token) == "" {
+		return nil, fmt.Errorf("%w: oidc jwt attestation is required", core.ErrInvalidRequest)
+	}
+
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(in.Token, claims, func(token *jwt.Token) (any, error) {
+		return v.keyfunc(ctx, token)
+	}, jwt.WithIssuer(v.issuer), jwt.WithAudience(v.audience))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", core.ErrUnauthorized, err)
+	}
+	if !parsed.Valid {
+		return nil, fmt.Errorf("%w: invalid oidc token", core.ErrUnauthorized)
+	}
+
+	subject, _ := claims["sub"].(string)
+	if strings.TrimSpace(subject) == "" {
+		return nil, fmt.Errorf("%w: oidc token missing subject", core.ErrUnauthorized)
+	}
+	if len(v.allowedSubjectPrefixes) > 0 && !hasAllowedSubjectPrefix(subject, v.allowedSubjectPrefixes) {
+		return nil, fmt.Errorf("%w: unexpected oidc subject %q", core.ErrUnauthorized, subject)
+	}
+
+	issuer, _ := claims["iss"].(string)
+	identity := &core.WorkloadIdentity{
+		Type:       core.WorkloadIdentityTypeOIDC,
+		Issuer:     issuer,
+		Subject:    subject,
+		Audience:   claimAudience(claims["aud"], v.audience),
+		Attributes: map[string]string{},
+	}
+	copyStringClaim(identity.Attributes, claims, "actor")
+	copyStringClaim(identity.Attributes, claims, "environment")
+	copyStringClaim(identity.Attributes, claims, "event_name")
+	copyStringClaim(identity.Attributes, claims, "job_workflow_ref")
+	copyStringClaim(identity.Attributes, claims, "ref")
+	copyStringClaim(identity.Attributes, claims, "repository")
+	copyStringClaim(identity.Attributes, claims, "repository_owner")
+	copyStringClaim(identity.Attributes, claims, "repository_visibility")
+	copyStringClaim(identity.Attributes, claims, "runner_environment")
+	copyStringClaim(identity.Attributes, claims, "sha")
+	copyStringClaim(identity.Attributes, claims, "workflow")
+	copyNumericClaim(identity.Attributes, claims, "run_attempt")
+	copyNumericClaim(identity.Attributes, claims, "run_id")
+	if len(identity.Attributes) == 0 {
+		identity.Attributes = map[string]string{}
+	}
+	return identity, nil
+}
+
+func hasAllowedSubjectPrefix(subject string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(subject, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func claimAudience(value any, fallback string) string {
+	switch audience := value.(type) {
+	case string:
+		if trimmed := strings.TrimSpace(audience); trimmed != "" {
+			return trimmed
+		}
+	case []string:
+		if len(audience) > 0 && strings.TrimSpace(audience[0]) != "" {
+			return strings.TrimSpace(audience[0])
+		}
+	case []any:
+		for _, candidate := range audience {
+			if text, ok := candidate.(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return fallback
+}
+
+func copyStringClaim(attributes map[string]string, claims jwt.MapClaims, key string) {
+	if value, ok := claims[key].(string); ok && strings.TrimSpace(value) != "" {
+		attributes[key] = strings.TrimSpace(value)
+	}
+}
+
+func copyNumericClaim(attributes map[string]string, claims jwt.MapClaims, key string) {
+	switch value := claims[key].(type) {
+	case float64:
+		attributes[key] = strconv.FormatInt(int64(value), 10)
+	case int64:
+		attributes[key] = strconv.FormatInt(value, 10)
+	case int32:
+		attributes[key] = strconv.FormatInt(int64(value), 10)
+	case string:
+		if strings.TrimSpace(value) != "" {
+			attributes[key] = strings.TrimSpace(value)
+		}
+	}
+}

--- a/internal/authn/oidc/verifier_test.go
+++ b/internal/authn/oidc/verifier_test.go
@@ -1,0 +1,114 @@
+package oidc_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/evalops/asb/internal/authn/oidc"
+	"github.com/evalops/asb/internal/core"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestVerifier_VerifyGitHubActionsToken(t *testing.T) {
+	t.Parallel()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"iss":                   "https://token.actions.githubusercontent.com",
+		"sub":                   "repo:evalops/asb:ref:refs/heads/main",
+		"aud":                   "asb-control-plane",
+		"exp":                   time.Now().Add(5 * time.Minute).Unix(),
+		"iat":                   time.Now().Add(-time.Minute).Unix(),
+		"actor":                 "haasonsaas",
+		"repository":            "evalops/asb",
+		"repository_owner":      "evalops",
+		"job_workflow_ref":      "evalops/asb/.github/workflows/ci.yml@refs/heads/main",
+		"sha":                   "abc123",
+		"ref":                   "refs/heads/main",
+		"run_id":                float64(42),
+		"run_attempt":           float64(2),
+		"runner_environment":    "github-hosted",
+		"repository_visibility": "private",
+	})
+	raw, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+
+	verifier, err := oidc.NewVerifier(oidc.Config{
+		Issuer:                 "https://token.actions.githubusercontent.com",
+		Audience:               "asb-control-plane",
+		AllowedSubjectPrefixes: []string{"repo:evalops/"},
+		Keyfunc: func(context.Context, *jwt.Token) (any, error) {
+			return publicKey, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier() error = %v", err)
+	}
+
+	identity, err := verifier.Verify(context.Background(), &core.Attestation{
+		Kind:  core.AttestationKindOIDCJWT,
+		Token: raw,
+	})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if identity.Type != core.WorkloadIdentityTypeOIDC {
+		t.Fatalf("Type = %q, want %q", identity.Type, core.WorkloadIdentityTypeOIDC)
+	}
+	if identity.Subject != "repo:evalops/asb:ref:refs/heads/main" {
+		t.Fatalf("Subject = %q, want GitHub Actions subject", identity.Subject)
+	}
+	if identity.Attributes["repository"] != "evalops/asb" {
+		t.Fatalf("repository = %q, want evalops/asb", identity.Attributes["repository"])
+	}
+	if identity.Attributes["run_id"] != "42" {
+		t.Fatalf("run_id = %q, want 42", identity.Attributes["run_id"])
+	}
+}
+
+func TestVerifier_RejectsUnexpectedSubjectPrefix(t *testing.T) {
+	t.Parallel()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"iss": "https://token.actions.githubusercontent.com",
+		"sub": "repo:other-org/repo:ref:refs/heads/main",
+		"aud": "asb-control-plane",
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+	raw, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+
+	verifier, err := oidc.NewVerifier(oidc.Config{
+		Issuer:                 "https://token.actions.githubusercontent.com",
+		Audience:               "asb-control-plane",
+		AllowedSubjectPrefixes: []string{"repo:evalops/"},
+		Keyfunc: func(context.Context, *jwt.Token) (any, error) {
+			return publicKey, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier() error = %v", err)
+	}
+
+	if _, err := verifier.Verify(context.Background(), &core.Attestation{
+		Kind:  core.AttestationKindOIDCJWT,
+		Token: raw,
+	}); err == nil {
+		t.Fatal("Verify() error = nil, want non-nil")
+	}
+}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -21,6 +21,7 @@ import (
 	auditmemory "github.com/evalops/asb/internal/audit/memory"
 	"github.com/evalops/asb/internal/authn/delegationjwt"
 	"github.com/evalops/asb/internal/authn/k8s"
+	"github.com/evalops/asb/internal/authn/oidc"
 	"github.com/evalops/asb/internal/authz/policy"
 	"github.com/evalops/asb/internal/authz/toolregistry"
 	browserconnector "github.com/evalops/asb/internal/connectors/browser"
@@ -332,31 +333,90 @@ func runProbe(ctx context.Context, probe readinessProbe) ReadinessCheck {
 }
 
 func newVerifier(require bool) (core.AttestationVerifier, error) {
-	issuer := os.Getenv("ASB_K8S_ISSUER")
-	publicKeyFile := os.Getenv("ASB_K8S_PUBLIC_KEY_FILE")
-	if issuer == "" || publicKeyFile == "" {
+	verifiers := map[core.AttestationKind]core.AttestationVerifier{}
+
+	k8sIssuer := strings.TrimSpace(os.Getenv("ASB_K8S_ISSUER"))
+	k8sPublicKeyFile := strings.TrimSpace(os.Getenv("ASB_K8S_PUBLIC_KEY_FILE"))
+	switch {
+	case k8sIssuer == "" && k8sPublicKeyFile == "":
+	case k8sIssuer == "" || k8sPublicKeyFile == "":
+		return nil, fmt.Errorf("incomplete k8s verifier configuration: ASB_K8S_ISSUER and ASB_K8S_PUBLIC_KEY_FILE must both be set")
+	default:
+		publicKey, err := loadPublicKey(k8sPublicKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		verifier, err := k8s.NewVerifier(k8s.Config{
+			Issuer:   k8sIssuer,
+			Audience: getenv("ASB_K8S_AUDIENCE", "asb-control-plane"),
+			Keyfunc: func(context.Context, *jwt.Token) (any, error) {
+				return publicKey, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		verifiers[core.AttestationKindK8SServiceAccountJWT] = verifier
+	}
+
+	oidcIssuer := strings.TrimSpace(os.Getenv("ASB_OIDC_ISSUER"))
+	oidcPublicKeyFile := strings.TrimSpace(os.Getenv("ASB_OIDC_PUBLIC_KEY_FILE"))
+	switch {
+	case oidcIssuer == "" && oidcPublicKeyFile == "":
+	case oidcIssuer == "" || oidcPublicKeyFile == "":
+		return nil, fmt.Errorf("incomplete oidc verifier configuration: ASB_OIDC_ISSUER and ASB_OIDC_PUBLIC_KEY_FILE must both be set")
+	default:
+		publicKey, err := loadPublicKey(oidcPublicKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		verifier, err := oidc.NewVerifier(oidc.Config{
+			Issuer:                 oidcIssuer,
+			Audience:               getenv("ASB_OIDC_AUDIENCE", "asb-control-plane"),
+			AllowedSubjectPrefixes: splitCommaSeparatedEnv("ASB_OIDC_ALLOWED_SUBJECT_PREFIXES"),
+			Keyfunc: func(context.Context, *jwt.Token) (any, error) {
+				return publicKey, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		verifiers[core.AttestationKindOIDCJWT] = verifier
+	}
+
+	switch len(verifiers) {
+	case 0:
 		if require {
-			return nil, fmt.Errorf("missing verifier configuration: ASB_K8S_ISSUER and ASB_K8S_PUBLIC_KEY_FILE are required")
+			return nil, fmt.Errorf("missing verifier configuration: configure ASB_K8S_ISSUER/ASB_K8S_PUBLIC_KEY_FILE or ASB_OIDC_ISSUER/ASB_OIDC_PUBLIC_KEY_FILE")
 		}
 		return noopVerifier{}, nil
+	case 1:
+		for _, verifier := range verifiers {
+			return verifier, nil
+		}
 	}
-	publicKey, err := loadPublicKey(publicKeyFile)
-	if err != nil {
-		return nil, err
-	}
-	return k8s.NewVerifier(k8s.Config{
-		Issuer:   issuer,
-		Audience: getenv("ASB_K8S_AUDIENCE", "asb-control-plane"),
-		Keyfunc: func(context.Context, *jwt.Token) (any, error) {
-			return publicKey, nil
-		},
-	})
+	return multiVerifier{verifiers: verifiers}, nil
 }
 
 type noopVerifier struct{}
 
 func (noopVerifier) Verify(context.Context, *core.Attestation) (*core.WorkloadIdentity, error) {
 	return nil, fmt.Errorf("attestation verification is not configured in this process")
+}
+
+type multiVerifier struct {
+	verifiers map[core.AttestationKind]core.AttestationVerifier
+}
+
+func (v multiVerifier) Verify(ctx context.Context, in *core.Attestation) (*core.WorkloadIdentity, error) {
+	if in == nil {
+		return nil, fmt.Errorf("%w: attestation is required", core.ErrInvalidRequest)
+	}
+	verifier, ok := v.verifiers[in.Kind]
+	if !ok {
+		return nil, fmt.Errorf("%w: unsupported attestation kind %q", core.ErrInvalidRequest, in.Kind)
+	}
+	return verifier.Verify(ctx, in)
 }
 
 func newSessionTokenManager() (core.SessionTokenManager, error) {
@@ -597,6 +657,24 @@ func getenv(key string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func splitCommaSeparatedEnv(key string) []string {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
 }
 
 func mustRegisterToolAndPolicy(ctx context.Context, logger *slog.Logger, tools *toolregistry.Registry, engine *policy.Engine, tenantID string, tool core.Tool, pol core.Policy) {

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -1,6 +1,11 @@
 package bootstrap
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -65,4 +70,58 @@ func TestNewApprovalNotifierConfigured(t *testing.T) {
 	if notifier == nil {
 		t.Fatal("newApprovalNotifier() = nil, want configured notifier")
 	}
+}
+
+func TestNewVerifierReturnsOIDCVerifierWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	publicKeyPath := writeEd25519PublicKeyFile(t, dir, "oidc.pub.pem")
+
+	t.Setenv("ASB_K8S_ISSUER", "")
+	t.Setenv("ASB_K8S_PUBLIC_KEY_FILE", "")
+	t.Setenv("ASB_OIDC_ISSUER", "https://token.actions.githubusercontent.com")
+	t.Setenv("ASB_OIDC_PUBLIC_KEY_FILE", publicKeyPath)
+	t.Setenv("ASB_OIDC_AUDIENCE", "asb-control-plane")
+	t.Setenv("ASB_OIDC_ALLOWED_SUBJECT_PREFIXES", "repo:evalops/")
+
+	verifier, err := newVerifier(true)
+	if err != nil {
+		t.Fatalf("newVerifier() error = %v", err)
+	}
+	if verifier == nil {
+		t.Fatal("newVerifier() = nil, want configured verifier")
+	}
+}
+
+func TestNewVerifierRequiresCompleteOIDCConfiguration(t *testing.T) {
+	t.Setenv("ASB_K8S_ISSUER", "")
+	t.Setenv("ASB_K8S_PUBLIC_KEY_FILE", "")
+	t.Setenv("ASB_OIDC_ISSUER", "https://token.actions.githubusercontent.com")
+	t.Setenv("ASB_OIDC_PUBLIC_KEY_FILE", "")
+
+	verifier, err := newVerifier(true)
+	if err == nil || !strings.Contains(err.Error(), "ASB_OIDC_ISSUER and ASB_OIDC_PUBLIC_KEY_FILE") {
+		t.Fatalf("newVerifier() error = %v, want oidc config error", err)
+	}
+	if verifier != nil {
+		t.Fatalf("newVerifier() = %#v, want nil", verifier)
+	}
+}
+
+func writeEd25519PublicKeyFile(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	publicKey, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	encoded, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey() error = %v", err)
+	}
+	path := filepath.Join(dir, name)
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: encoded}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -89,12 +89,14 @@ type WorkloadIdentityType string
 
 const (
 	WorkloadIdentityTypeK8SSA WorkloadIdentityType = "k8s_sa"
+	WorkloadIdentityTypeOIDC  WorkloadIdentityType = "oidc"
 )
 
 type AttestationKind string
 
 const (
 	AttestationKindK8SServiceAccountJWT AttestationKind = "k8s_sa_jwt"
+	AttestationKindOIDCJWT              AttestationKind = "oidc_jwt"
 )
 
 type ResourceKind string


### PR DESCRIPTION
## Summary
- add `oidc_jwt` workload attestation support alongside the existing Kubernetes SA JWT path
- allow ASB bootstrap to load Kubernetes, OIDC, or both verifier modes from env config
- normalize GitHub Actions-style OIDC claims into the workload identity attributes exposed to policy and audit flows

## Scope
Refs #54. This is the OIDC workload-identity portion only; local development bootstrap remains separate work.

## Validation
- go test ./... -count=1
- GOTOOLCHAIN=go1.26.0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./internal/authn/oidc ./internal/bootstrap ./internal/api/connectapi ./internal/core

## Notes
- repo-wide golangci-lint still reports unrelated pre-existing failures on untouched files from `main`, so lint was run against the touched packages for this slice