### PR TITLE
Cache GitHub App tokens in Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Primary persistence for sessions, grants, approvals, artifacts, and audit events
 
 ### Redis
 
-Runtime state only, not source-of-truth persistence. Used for proxy handle budgets and browser relay session state when `ASB_REDIS_ADDR` is set. Keys are set with automatic expiry. Watch-based transactions enforce concurrent budget limits. No durability guarantees — state is reconstructable from Postgres.
+Runtime state only, not source-of-truth persistence. Used for proxy handle budgets, browser relay session state, and shared GitHub App installation-token caching when `ASB_REDIS_ADDR` is set. Keys are set with automatic expiry. Watch-based transactions enforce concurrent budget limits. No durability guarantees — state is reconstructable from Postgres.
 
 ### In-memory
 
@@ -235,7 +235,7 @@ Flags: `-interval` (default 30s), `-limit` (default 100 per pass), `-once` (sing
 | `ASB_ADDR` | Listen address (default `:8080`) |
 | `ASB_DEV_TENANT_ID` | Tenant ID for local development |
 | `ASB_POSTGRES_DSN` | Enables Postgres repository |
-| `ASB_REDIS_ADDR` | Enables Redis runtime store |
+| `ASB_REDIS_ADDR` | Enables Redis runtime store and shared GitHub App token cache |
 | `ASB_REDIS_PASSWORD` | Redis authentication |
 | `ASB_HTTP_MAX_BODY_BYTES` | Maximum JSON request body size |
 | `ASB_HTTP_READ_TIMEOUT` | HTTP server read timeout |

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -104,7 +104,7 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 	if err != nil {
 		return nil, err
 	}
-	runtimeStore, cleanupRuntime, redisProbe, redisStats, err := newRuntimeStore(ctx)
+	runtimeStore, redisClient, cleanupRuntime, redisProbe, redisStats, err := newRuntimeStore(ctx)
 	if err != nil {
 		cleanupRepository()
 		return nil, err
@@ -117,7 +117,7 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 		resolver.WithGitHub(githubconnector.NewConnector(githubconnector.Config{})),
 	}
 
-	githubProxy, err := newGitHubProxyExecutor()
+	githubProxy, err := newGitHubProxyExecutor(redisClient)
 	if err != nil {
 		cleanupRuntime()
 		cleanupRepository()
@@ -383,7 +383,7 @@ func newDelegationValidator() (core.DelegationValidator, error) {
 	})
 }
 
-func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
+func newGitHubProxyExecutor(redisClient goredis.UniversalClient) (core.GitHubProxyExecutor, error) {
 	var tokenSource githubconnector.RepoTokenSource
 	var staticTokenSource githubconnector.RepoTokenSource
 	if token := os.Getenv("ASB_GITHUB_TOKEN"); token != "" {
@@ -409,6 +409,7 @@ func newGitHubProxyExecutor() (core.GitHubProxyExecutor, error) {
 			AppID:       appID,
 			PrivateKey:  privateKey,
 			BaseURL:     getenv("ASB_GITHUB_API_BASE_URL", "https://api.github.com"),
+			Cache:       githubconnector.NewRedisAppTokenCache(githubconnector.RedisAppTokenCacheConfig{Client: redisClient}),
 			Permissions: permissions,
 		})
 		if err != nil {
@@ -469,7 +470,7 @@ func newRepository(ctx context.Context) (core.Repository, func(), readinessProbe
 	return memstore.NewRepository(), func() {}, nil, nil, nil
 }
 
-func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), readinessProbe, func() *goredis.PoolStats, error) {
+func newRuntimeStore(ctx context.Context) (core.RuntimeStore, goredis.UniversalClient, func(), readinessProbe, func() *goredis.PoolStats, error) {
 	if addr := os.Getenv("ASB_REDIS_ADDR"); addr != "" {
 		client := goredis.NewClient(&goredis.Options{
 			Addr:     addr,
@@ -479,17 +480,17 @@ func newRuntimeStore(ctx context.Context) (core.RuntimeStore, func(), readinessP
 		closeClient := func() { _ = client.Close() }
 		if err := instrumentDefaultRedisClient(client); err != nil {
 			closeClient()
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		if err := client.Ping(ctx).Err(); err != nil {
 			closeClient()
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
-		return redisstore.NewRuntimeStore(client), closeClient, func(ctx context.Context) error {
+		return redisstore.NewRuntimeStore(client), client, closeClient, func(ctx context.Context) error {
 			return client.Ping(ctx).Err()
 		}, redisPoolStats(client), nil
 	}
-	return memstore.NewRuntimeStore(), func() {}, nil, nil, nil
+	return memstore.NewRuntimeStore(), nil, func() {}, nil, nil, nil
 }
 
 func pgxPoolDBStats(pool *pgxpool.Pool) func() sql.DBStats {

--- a/internal/connectors/github/app_token_source.go
+++ b/internal/connectors/github/app_token_source.go
@@ -22,6 +22,7 @@ type AppTokenSourceConfig struct {
 	PrivateKey  *rsa.PrivateKey
 	BaseURL     string
 	Client      *http.Client
+	Cache       AppTokenCache
 	Permissions map[string]string
 	Now         func() time.Time
 }
@@ -31,6 +32,7 @@ type AppTokenSource struct {
 	privateKey  *rsa.PrivateKey
 	baseURL     string
 	client      *http.Client
+	cache       AppTokenCache
 	permissions map[string]string
 	now         func() time.Time
 
@@ -70,6 +72,7 @@ func NewAppTokenSource(cfg AppTokenSourceConfig) (*AppTokenSource, error) {
 		privateKey:        cfg.PrivateKey,
 		baseURL:           strings.TrimRight(cfg.BaseURL, "/"),
 		client:            cfg.Client,
+		cache:             cfg.Cache,
 		permissions:       cfg.Permissions,
 		now:               cfg.Now,
 		repoInstallations: make(map[string]int64),
@@ -80,16 +83,12 @@ func NewAppTokenSource(cfg AppTokenSourceConfig) (*AppTokenSource, error) {
 func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
 	repoKey := owner + "/" + repo
 
-	s.mu.Lock()
-	installationID, ok := s.repoInstallations[repoKey]
+	installationID, ok := s.lookupInstallationIDCache(ctx, repoKey)
 	if ok {
-		if cached, ok := s.installationCache[installationID]; ok && cached.expiresAt.After(s.now().Add(5*time.Minute)) {
-			token := cached.token
-			s.mu.Unlock()
-			return token, nil
+		if cached, ok := s.lookupInstallationTokenCache(ctx, installationID); ok {
+			return cached.token, nil
 		}
 	}
-	s.mu.Unlock()
 
 	appToken, err := s.appJWT()
 	if err != nil {
@@ -101,23 +100,76 @@ func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo st
 		if err != nil {
 			return "", err
 		}
-		s.mu.Lock()
-		s.repoInstallations[repoKey] = installationID
-		s.mu.Unlock()
+		s.storeInstallationIDCache(ctx, repoKey, installationID)
 	}
 
 	token, expiresAt, err := s.createInstallationToken(ctx, installationID, repo, appToken)
 	if err != nil {
 		return "", err
 	}
-
-	s.mu.Lock()
-	s.installationCache[installationID] = cachedInstallationToken{
+	s.storeInstallationTokenCache(ctx, installationID, cachedInstallationToken{
 		token:     token,
 		expiresAt: expiresAt,
-	}
-	s.mu.Unlock()
+	})
 	return token, nil
+}
+
+func (s *AppTokenSource) lookupInstallationIDCache(ctx context.Context, repoKey string) (int64, bool) {
+	s.mu.Lock()
+	installationID, ok := s.repoInstallations[repoKey]
+	s.mu.Unlock()
+	if ok {
+		return installationID, true
+	}
+	if s.cache == nil {
+		return 0, false
+	}
+	installationID, ok, err := s.cache.GetRepoInstallation(ctx, repoKey)
+	if err != nil || !ok {
+		return 0, false
+	}
+	s.mu.Lock()
+	s.repoInstallations[repoKey] = installationID
+	s.mu.Unlock()
+	return installationID, true
+}
+
+func (s *AppTokenSource) storeInstallationIDCache(ctx context.Context, repoKey string, installationID int64) {
+	s.mu.Lock()
+	s.repoInstallations[repoKey] = installationID
+	s.mu.Unlock()
+	if s.cache != nil {
+		_ = s.cache.SetRepoInstallation(ctx, repoKey, installationID)
+	}
+}
+
+func (s *AppTokenSource) lookupInstallationTokenCache(ctx context.Context, installationID int64) (cachedInstallationToken, bool) {
+	s.mu.Lock()
+	cached, ok := s.installationCache[installationID]
+	s.mu.Unlock()
+	if ok && cached.expiresAt.After(s.now().Add(5*time.Minute)) {
+		return cached, true
+	}
+	if s.cache == nil {
+		return cachedInstallationToken{}, false
+	}
+	cached, ok, err := s.cache.GetInstallationToken(ctx, installationID)
+	if err != nil || !ok || !cached.expiresAt.After(s.now().Add(5*time.Minute)) {
+		return cachedInstallationToken{}, false
+	}
+	s.mu.Lock()
+	s.installationCache[installationID] = cached
+	s.mu.Unlock()
+	return cached, true
+}
+
+func (s *AppTokenSource) storeInstallationTokenCache(ctx context.Context, installationID int64, cached cachedInstallationToken) {
+	s.mu.Lock()
+	s.installationCache[installationID] = cached
+	s.mu.Unlock()
+	if s.cache != nil {
+		_ = s.cache.SetInstallationToken(ctx, installationID, cached)
+	}
 }
 
 func (s *AppTokenSource) appJWT() (string, error) {

--- a/internal/connectors/github/app_token_source_test.go
+++ b/internal/connectors/github/app_token_source_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/evalops/asb/internal/connectors/github"
 	"github.com/evalops/asb/internal/core"
 	"github.com/golang-jwt/jwt/v5"
+	goredis "github.com/redis/go-redis/v9"
 )
 
 func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T) {
@@ -182,6 +184,87 @@ func TestAppTokenSource_ClassifiesGitHubErrors(t *testing.T) {
 				t.Fatalf("TokenForRepo() error = %v, want %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestAppTokenSource_TokenForRepoUsesRedisSharedCache(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+
+	redisServer, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer redisServer.Close()
+
+	redisClient := goredis.NewClient(&goredis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		_ = redisClient.Close()
+	})
+
+	installationLookups := 0
+	tokenRequests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widgets/installation":
+			installationLookups++
+			_, _ = w.Write([]byte(`{"id":987}`))
+		case "/app/installations/987/access_tokens":
+			tokenRequests++
+			_, _ = w.Write([]byte(`{"token":"inst-token","expires_at":"` + now.Add(10*time.Minute).Format(time.RFC3339) + `"}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cache := github.NewRedisAppTokenCache(github.RedisAppTokenCacheConfig{Client: redisClient})
+	first, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Cache:      cache,
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() first error = %v", err)
+	}
+	second, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Cache:      cache,
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() second error = %v", err)
+	}
+
+	firstToken, err := first.TokenForRepo(context.Background(), "acme", "widgets")
+	if err != nil {
+		t.Fatalf("TokenForRepo() first error = %v", err)
+	}
+	secondToken, err := second.TokenForRepo(context.Background(), "acme", "widgets")
+	if err != nil {
+		t.Fatalf("TokenForRepo() second error = %v", err)
+	}
+	if firstToken != secondToken {
+		t.Fatalf("tokens = %q/%q, want shared cached token", firstToken, secondToken)
+	}
+	if installationLookups != 1 || tokenRequests != 1 {
+		t.Fatalf("lookups/requests = %d/%d, want 1/1", installationLookups, tokenRequests)
 	}
 }
 

--- a/internal/connectors/github/token_cache.go
+++ b/internal/connectors/github/token_cache.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const defaultRepoInstallationTTL = 24 * time.Hour
+
+type AppTokenCache interface {
+	GetRepoInstallation(ctx context.Context, repoKey string) (int64, bool, error)
+	SetRepoInstallation(ctx context.Context, repoKey string, installationID int64) error
+	GetInstallationToken(ctx context.Context, installationID int64) (cachedInstallationToken, bool, error)
+	SetInstallationToken(ctx context.Context, installationID int64, token cachedInstallationToken) error
+}
+
+type RedisAppTokenCacheConfig struct {
+	Client              goredis.UniversalClient
+	KeyPrefix           string
+	RepoInstallationTTL time.Duration
+}
+
+type redisAppTokenCache struct {
+	client              goredis.UniversalClient
+	keyPrefix           string
+	repoInstallationTTL time.Duration
+}
+
+type redisCachedInstallationToken struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func NewRedisAppTokenCache(cfg RedisAppTokenCacheConfig) AppTokenCache {
+	if cfg.Client == nil {
+		return nil
+	}
+	if cfg.RepoInstallationTTL <= 0 {
+		cfg.RepoInstallationTTL = defaultRepoInstallationTTL
+	}
+	return &redisAppTokenCache{
+		client:              cfg.Client,
+		keyPrefix:           strings.TrimSpace(cfg.KeyPrefix),
+		repoInstallationTTL: cfg.RepoInstallationTTL,
+	}
+}
+
+func (c *redisAppTokenCache) GetRepoInstallation(ctx context.Context, repoKey string) (int64, bool, error) {
+	value, err := c.client.Get(ctx, c.repoInstallationKey(repoKey)).Result()
+	if err == goredis.Nil {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	installationID, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false, err
+	}
+	return installationID, true, nil
+}
+
+func (c *redisAppTokenCache) SetRepoInstallation(ctx context.Context, repoKey string, installationID int64) error {
+	return c.client.Set(
+		ctx,
+		c.repoInstallationKey(repoKey),
+		strconv.FormatInt(installationID, 10),
+		c.repoInstallationTTL,
+	).Err()
+}
+
+func (c *redisAppTokenCache) GetInstallationToken(ctx context.Context, installationID int64) (cachedInstallationToken, bool, error) {
+	value, err := c.client.Get(ctx, c.installationTokenKey(installationID)).Bytes()
+	if err == goredis.Nil {
+		return cachedInstallationToken{}, false, nil
+	}
+	if err != nil {
+		return cachedInstallationToken{}, false, err
+	}
+	var cached cachedInstallationToken
+	var payload redisCachedInstallationToken
+	if err := json.Unmarshal(value, &payload); err != nil {
+		return cachedInstallationToken{}, false, err
+	}
+	cached.token = payload.Token
+	cached.expiresAt = payload.ExpiresAt
+	return cached, true, nil
+}
+
+func (c *redisAppTokenCache) SetInstallationToken(ctx context.Context, installationID int64, token cachedInstallationToken) error {
+	ttl := time.Until(token.expiresAt)
+	if ttl <= 0 {
+		return nil
+	}
+	payload, err := json.Marshal(redisCachedInstallationToken{
+		Token:     token.token,
+		ExpiresAt: token.expiresAt,
+	})
+	if err != nil {
+		return err
+	}
+	return c.client.Set(ctx, c.installationTokenKey(installationID), payload, ttl).Err()
+}
+
+func (c *redisAppTokenCache) repoInstallationKey(repoKey string) string {
+	return fmt.Sprintf("%sgithub:repo-installation:%s", c.keyPrefix, repoKey)
+}
+
+func (c *redisAppTokenCache) installationTokenKey(installationID int64) string {
+	return fmt.Sprintf("%sgithub:installation-token:%d", c.keyPrefix, installationID)
+}


### PR DESCRIPTION
## Summary
- back the GitHub App repo-installation and installation-token cache with Redis when ASB already has Redis configured
- keep the existing in-memory fast path and fall back cleanly if the shared cache misses or errors
- document that ASB Redis now also serves as the shared GitHub App token cache

## Testing
- go test ./internal/connectors/github ./internal/bootstrap -count=1
- go test ./... -count=1
- GOTOOLCHAIN=go1.26.0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./internal/connectors/github ./internal/bootstrap

Refs EvalOps/asb#12
