### PR TITLE
Add scoped GitHub proxy write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ Configure at least one attestation verifier:
 | `ASB_HTTP_SHUTDOWN_TIMEOUT` | API shutdown drain timeout |
 | `ASB_GITHUB_TOKEN` | Static GitHub token (dev) |
 | `ASB_GITHUB_API_BASE_URL` | GitHub API base URL override |
+| `ASB_GITHUB_ALLOWED_OPERATIONS` | Comma-separated GitHub proxy operations; defaults to read-only operations |
 | `ASB_GITHUB_APP_ID` | GitHub App ID |
 | `ASB_GITHUB_APP_PRIVATE_KEY_FILE` | GitHub App private key |
-| `ASB_GITHUB_APP_PERMISSIONS_JSON` | GitHub App token permissions |
+| `ASB_GITHUB_APP_PERMISSIONS_JSON` | Override read-operation GitHub App token permissions |
 | `ASB_DELEGATION_ISSUER` | Delegation JWT issuer |
 | `ASB_DELEGATION_PUBLIC_KEY_FILE` | Delegation JWT public key |
 | `ASB_SESSION_SIGNING_PRIVATE_KEY_FILE` | Ed25519 private key for session tokens |

--- a/internal/api/httpapi/server.go
+++ b/internal/api/httpapi/server.go
@@ -414,7 +414,9 @@ func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, out any) err
 	}
 
 	body := http.MaxBytesReader(w, r.Body, s.maxBody)
-	defer body.Close()
+	defer func() {
+		_ = body.Close()
+	}()
 
 	decoder := json.NewDecoder(body)
 	decoder.DisallowUnknownFields()

--- a/internal/app/cleanup.go
+++ b/internal/app/cleanup.go
@@ -242,10 +242,3 @@ func (s *Service) transitionGrantState(ctx context.Context, session *core.Sessio
 
 	return nil
 }
-
-func (s *Service) cleanupSummary(stats *CleanupStats) string {
-	if stats == nil {
-		return ""
-	}
-	return fmt.Sprintf("approvals=%d sessions=%d grants=%d artifacts=%d", stats.ApprovalsExpired, stats.SessionsExpired, stats.GrantsExpired, stats.ArtifactsExpired)
-}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -115,7 +115,9 @@ func NewServiceRuntime(ctx context.Context, logger *slog.Logger, options ...Serv
 	tools := toolregistry.New()
 	engine := policy.NewEngine()
 	connectorOptions := []resolver.Option{
-		resolver.WithGitHub(githubconnector.NewConnector(githubconnector.Config{})),
+		resolver.WithGitHub(githubconnector.NewConnector(githubconnector.Config{
+			AllowedOperations: splitCommaSeparatedEnv("ASB_GITHUB_ALLOWED_OPERATIONS"),
+		})),
 	}
 
 	githubProxy, err := newGitHubProxyExecutor(redisClient)

--- a/internal/connectors/github/app_token_source.go
+++ b/internal/connectors/github/app_token_source.go
@@ -28,17 +28,17 @@ type AppTokenSourceConfig struct {
 }
 
 type AppTokenSource struct {
-	appID       int64
-	privateKey  *rsa.PrivateKey
-	baseURL     string
-	client      *http.Client
-	cache       AppTokenCache
-	permissions map[string]string
-	now         func() time.Time
+	appID           int64
+	privateKey      *rsa.PrivateKey
+	baseURL         string
+	client          *http.Client
+	cache           AppTokenCache
+	readPermissions map[string]string
+	now             func() time.Time
 
 	mu                sync.Mutex
 	repoInstallations map[string]int64
-	installationCache map[int64]cachedInstallationToken
+	installationCache map[string]cachedInstallationToken
 }
 
 type cachedInstallationToken struct {
@@ -59,33 +59,27 @@ func NewAppTokenSource(cfg AppTokenSourceConfig) (*AppTokenSource, error) {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
-	if len(cfg.Permissions) == 0 {
-		cfg.Permissions = map[string]string{
-			"contents":      "read",
-			"issues":        "read",
-			"pull_requests": "read",
-		}
-	}
-
 	return &AppTokenSource{
 		appID:             cfg.AppID,
 		privateKey:        cfg.PrivateKey,
 		baseURL:           strings.TrimRight(cfg.BaseURL, "/"),
 		client:            cfg.Client,
 		cache:             cfg.Cache,
-		permissions:       cfg.Permissions,
+		readPermissions:   clonePermissions(cfg.Permissions),
 		now:               cfg.Now,
 		repoInstallations: make(map[string]int64),
-		installationCache: make(map[int64]cachedInstallationToken),
+		installationCache: make(map[string]cachedInstallationToken),
 	}, nil
 }
 
-func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
+func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo string, operation string) (string, error) {
 	repoKey := owner + "/" + repo
+	permissions := permissionsForOperation(operation, s.readPermissions)
+	scopeKey := permissionScopeKey(permissions)
 
 	installationID, ok := s.lookupInstallationIDCache(ctx, repoKey)
 	if ok {
-		if cached, ok := s.lookupInstallationTokenCache(ctx, installationID); ok {
+		if cached, ok := s.lookupInstallationTokenCache(ctx, installationID, scopeKey); ok {
 			return cached.token, nil
 		}
 	}
@@ -103,11 +97,11 @@ func (s *AppTokenSource) TokenForRepo(ctx context.Context, owner string, repo st
 		s.storeInstallationIDCache(ctx, repoKey, installationID)
 	}
 
-	token, expiresAt, err := s.createInstallationToken(ctx, installationID, repo, appToken)
+	token, expiresAt, err := s.createInstallationToken(ctx, installationID, repo, appToken, permissions)
 	if err != nil {
 		return "", err
 	}
-	s.storeInstallationTokenCache(ctx, installationID, cachedInstallationToken{
+	s.storeInstallationTokenCache(ctx, installationID, scopeKey, cachedInstallationToken{
 		token:     token,
 		expiresAt: expiresAt,
 	})
@@ -143,9 +137,10 @@ func (s *AppTokenSource) storeInstallationIDCache(ctx context.Context, repoKey s
 	}
 }
 
-func (s *AppTokenSource) lookupInstallationTokenCache(ctx context.Context, installationID int64) (cachedInstallationToken, bool) {
+func (s *AppTokenSource) lookupInstallationTokenCache(ctx context.Context, installationID int64, scopeKey string) (cachedInstallationToken, bool) {
+	cacheKey := installationCacheKey(installationID, scopeKey)
 	s.mu.Lock()
-	cached, ok := s.installationCache[installationID]
+	cached, ok := s.installationCache[cacheKey]
 	s.mu.Unlock()
 	if ok && cached.expiresAt.After(s.now().Add(5*time.Minute)) {
 		return cached, true
@@ -153,22 +148,23 @@ func (s *AppTokenSource) lookupInstallationTokenCache(ctx context.Context, insta
 	if s.cache == nil {
 		return cachedInstallationToken{}, false
 	}
-	cached, ok, err := s.cache.GetInstallationToken(ctx, installationID)
+	cached, ok, err := s.cache.GetInstallationToken(ctx, installationID, scopeKey)
 	if err != nil || !ok || !cached.expiresAt.After(s.now().Add(5*time.Minute)) {
 		return cachedInstallationToken{}, false
 	}
 	s.mu.Lock()
-	s.installationCache[installationID] = cached
+	s.installationCache[cacheKey] = cached
 	s.mu.Unlock()
 	return cached, true
 }
 
-func (s *AppTokenSource) storeInstallationTokenCache(ctx context.Context, installationID int64, cached cachedInstallationToken) {
+func (s *AppTokenSource) storeInstallationTokenCache(ctx context.Context, installationID int64, scopeKey string, cached cachedInstallationToken) {
+	cacheKey := installationCacheKey(installationID, scopeKey)
 	s.mu.Lock()
-	s.installationCache[installationID] = cached
+	s.installationCache[cacheKey] = cached
 	s.mu.Unlock()
 	if s.cache != nil {
-		_ = s.cache.SetInstallationToken(ctx, installationID, cached)
+		_ = s.cache.SetInstallationToken(ctx, installationID, scopeKey, cached)
 	}
 }
 
@@ -218,10 +214,10 @@ func (s *AppTokenSource) lookupInstallationID(ctx context.Context, owner string,
 	return payload.ID, nil
 }
 
-func (s *AppTokenSource) createInstallationToken(ctx context.Context, installationID int64, repo string, appToken string) (string, time.Time, error) {
+func (s *AppTokenSource) createInstallationToken(ctx context.Context, installationID int64, repo string, appToken string, permissions map[string]string) (string, time.Time, error) {
 	requestBody, err := json.Marshal(map[string]any{
 		"repositories": []string{repo},
-		"permissions":  s.permissions,
+		"permissions":  permissions,
 	})
 	if err != nil {
 		return "", time.Time{}, err
@@ -256,4 +252,8 @@ func (s *AppTokenSource) createInstallationToken(ctx context.Context, installati
 		return "", time.Time{}, err
 	}
 	return payload.Token, payload.ExpiresAt, nil
+}
+
+func installationCacheKey(installationID int64, scopeKey string) string {
+	return fmt.Sprintf("%d:%s", installationID, scopeKey)
 }

--- a/internal/connectors/github/app_token_source_test.go
+++ b/internal/connectors/github/app_token_source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +62,7 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 		t.Fatalf("NewAppTokenSource() error = %v", err)
 	}
 
-	token, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	token, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() error = %v", err)
 	}
@@ -69,7 +70,7 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 		t.Fatalf("token = %q, want inst-token", token)
 	}
 
-	cachedToken, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	cachedToken, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() cached error = %v", err)
 	}
@@ -78,6 +79,77 @@ func TestAppTokenSource_TokenForRepoUsesInstallationTokenAndCaches(t *testing.T)
 	}
 	if installationLookups != 1 || tokenRequests != 1 {
 		t.Fatalf("lookups/requests = %d/%d, want 1/1", installationLookups, tokenRequests)
+	}
+}
+
+func TestAppTokenSource_TokenForRepoScopesPermissionsByOperation(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tokenRequests := 0
+	requestedPermissions := make([]map[string]string, 0, 2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widgets/installation":
+			_, _ = w.Write([]byte(`{"id":987}`))
+		case "/app/installations/987/access_tokens":
+			tokenRequests++
+			var payload struct {
+				Permissions map[string]string `json:"permissions"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode() error = %v", err)
+			}
+			requestedPermissions = append(requestedPermissions, payload.Permissions)
+			tokenValue := "read-token"
+			if tokenRequests > 1 {
+				tokenValue = "write-token"
+			}
+			_, _ = w.Write([]byte(`{"token":"` + tokenValue + `","expires_at":"` + now.Add(10*time.Minute).Format(time.RFC3339) + `"}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	source, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() error = %v", err)
+	}
+
+	readToken, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
+	if err != nil {
+		t.Fatalf("TokenForRepo() read error = %v", err)
+	}
+	writeToken, err := source.TokenForRepo(context.Background(), "acme", "widgets", "create_issue")
+	if err != nil {
+		t.Fatalf("TokenForRepo() write error = %v", err)
+	}
+	if readToken == writeToken {
+		t.Fatalf("tokens = %q/%q, want distinct scope-specific tokens", readToken, writeToken)
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("token requests = %d, want 2", tokenRequests)
+	}
+	if got := requestedPermissions[0]["contents"]; got != "read" {
+		t.Fatalf("read permissions = %#v, want read scope", requestedPermissions[0])
+	}
+	if got := requestedPermissions[1]["issues"]; got != "write" || len(requestedPermissions[1]) != 1 {
+		t.Fatalf("write permissions = %#v, want issues:write only", requestedPermissions[1])
 	}
 }
 
@@ -122,12 +194,12 @@ func TestAppTokenSource_TokenForRepoRefreshesWhenTokenNearExpiry(t *testing.T) {
 		t.Fatalf("NewAppTokenSource() error = %v", err)
 	}
 
-	firstToken, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	firstToken, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() first error = %v", err)
 	}
 	currentTime = now.Add(2 * time.Minute)
-	secondToken, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	secondToken, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() second error = %v", err)
 	}
@@ -179,7 +251,7 @@ func TestAppTokenSource_ClassifiesGitHubErrors(t *testing.T) {
 				t.Fatalf("NewAppTokenSource() error = %v", err)
 			}
 
-			_, err = source.TokenForRepo(context.Background(), "acme", "widgets")
+			_, err = source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("TokenForRepo() error = %v, want %v", err, tc.wantErr)
 			}
@@ -252,11 +324,11 @@ func TestAppTokenSource_TokenForRepoUsesRedisSharedCache(t *testing.T) {
 		t.Fatalf("NewAppTokenSource() second error = %v", err)
 	}
 
-	firstToken, err := first.TokenForRepo(context.Background(), "acme", "widgets")
+	firstToken, err := first.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() first error = %v", err)
 	}
-	secondToken, err := second.TokenForRepo(context.Background(), "acme", "widgets")
+	secondToken, err := second.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() second error = %v", err)
 	}
@@ -265,6 +337,104 @@ func TestAppTokenSource_TokenForRepoUsesRedisSharedCache(t *testing.T) {
 	}
 	if installationLookups != 1 || tokenRequests != 1 {
 		t.Fatalf("lookups/requests = %d/%d, want 1/1", installationLookups, tokenRequests)
+	}
+}
+
+func TestAppTokenSource_TokenForRepoCachesByPermissionScope(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+
+	redisServer, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer redisServer.Close()
+
+	redisClient := goredis.NewClient(&goredis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		_ = redisClient.Close()
+	})
+
+	tokenRequests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widgets/installation":
+			_, _ = w.Write([]byte(`{"id":987}`))
+		case "/app/installations/987/access_tokens":
+			tokenRequests++
+			tokenValue := "read-token"
+			if tokenRequests > 1 {
+				tokenValue = "write-token"
+			}
+			_, _ = w.Write([]byte(`{"token":"` + tokenValue + `","expires_at":"` + now.Add(10*time.Minute).Format(time.RFC3339) + `"}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cache := github.NewRedisAppTokenCache(github.RedisAppTokenCacheConfig{Client: redisClient})
+	first, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Cache:      cache,
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() first error = %v", err)
+	}
+	second, err := github.NewAppTokenSource(github.AppTokenSourceConfig{
+		AppID:      123,
+		PrivateKey: privateKey,
+		BaseURL:    server.URL,
+		Client:     server.Client(),
+		Cache:      cache,
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAppTokenSource() second error = %v", err)
+	}
+
+	firstReadToken, err := first.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
+	if err != nil {
+		t.Fatalf("TokenForRepo() first read error = %v", err)
+	}
+	secondReadToken, err := second.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
+	if err != nil {
+		t.Fatalf("TokenForRepo() second read error = %v", err)
+	}
+	firstWriteToken, err := first.TokenForRepo(context.Background(), "acme", "widgets", "create_issue")
+	if err != nil {
+		t.Fatalf("TokenForRepo() first write error = %v", err)
+	}
+	secondWriteToken, err := second.TokenForRepo(context.Background(), "acme", "widgets", "create_issue")
+	if err != nil {
+		t.Fatalf("TokenForRepo() second write error = %v", err)
+	}
+
+	if firstReadToken != secondReadToken {
+		t.Fatalf("read tokens = %q/%q, want shared cached token", firstReadToken, secondReadToken)
+	}
+	if firstWriteToken != secondWriteToken {
+		t.Fatalf("write tokens = %q/%q, want shared cached token", firstWriteToken, secondWriteToken)
+	}
+	if firstReadToken == firstWriteToken {
+		t.Fatalf("read/write tokens = %q/%q, want cache separated by scope", firstReadToken, firstWriteToken)
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("token requests = %d, want 2", tokenRequests)
 	}
 }
 

--- a/internal/connectors/github/connector.go
+++ b/internal/connectors/github/connector.go
@@ -9,13 +9,6 @@ import (
 	"github.com/evalops/asb/internal/core"
 )
 
-var defaultOperations = []string{
-	"pull_request_metadata",
-	"pull_request_files",
-	"repository_metadata",
-	"repository_issues",
-}
-
 type Config struct {
 	AllowedOperations []string
 	Budget            core.ProxyBudget
@@ -27,8 +20,8 @@ type Connector struct {
 }
 
 func NewConnector(cfg Config) *Connector {
-	operations := append([]string(nil), cfg.AllowedOperations...)
-	if len(operations) == 0 {
+	operations := normalizeOperations(cfg.AllowedOperations)
+	if len(cfg.AllowedOperations) == 0 {
 		operations = append([]string(nil), defaultOperations...)
 	}
 	budget := cfg.Budget

--- a/internal/connectors/github/connector_test.go
+++ b/internal/connectors/github/connector_test.go
@@ -62,3 +62,30 @@ func TestConnector_IssueReturnsAllowlistedProxyHandle(t *testing.T) {
 		t.Fatalf("resource_ref = %q, want github repo ref", issued.Metadata["resource_ref"])
 	}
 }
+
+func TestConnector_IssueAllowsConfiguredWriteOperations(t *testing.T) {
+	t.Parallel()
+
+	connector := github.NewConnector(github.Config{
+		AllowedOperations: []string{"create_issue", "create_pull_request_comment", "create_check_run", "unknown"},
+	})
+
+	issued, err := connector.Issue(context.Background(), core.IssueRequest{
+		Session: &core.Session{ID: "sess_write", TenantID: "t_acme"},
+		Grant: &core.Grant{
+			ID:           "gr_write",
+			DeliveryMode: core.DeliveryModeProxy,
+			ExpiresAt:    time.Date(2026, 3, 12, 20, 10, 0, 0, time.UTC),
+		},
+		Resource: core.ResourceDescriptor{
+			Kind: core.ResourceKindGitHubRepo,
+			Name: "acme/widgets",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if got := issued.Metadata["operations"]; got != "create_issue,create_pull_request_comment,create_check_run" {
+		t.Fatalf("operations = %q, want configured write allowlist", got)
+	}
+}

--- a/internal/connectors/github/errors.go
+++ b/internal/connectors/github/errors.go
@@ -17,6 +17,8 @@ func classifyGitHubAPIError(response *http.Response, body []byte, action string)
 	switch {
 	case response.StatusCode == http.StatusUnauthorized:
 		return fmt.Errorf("%w: %s returned %d: %s", core.ErrUnauthorized, action, response.StatusCode, message)
+	case response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusUnprocessableEntity:
+		return fmt.Errorf("%w: %s returned %d: %s", core.ErrInvalidRequest, action, response.StatusCode, message)
 	case response.StatusCode == http.StatusTooManyRequests || response.Header.Get("Retry-After") != "" || response.Header.Get("X-RateLimit-Remaining") == "0":
 		return fmt.Errorf("%w: %s returned %d: %s", core.ErrRateLimited, action, response.StatusCode, message)
 	case response.StatusCode == http.StatusNotFound:

--- a/internal/connectors/github/executor.go
+++ b/internal/connectors/github/executor.go
@@ -1,7 +1,9 @@
 package github
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +15,7 @@ import (
 )
 
 type RepoTokenSource interface {
-	TokenForRepo(ctx context.Context, owner string, repo string) (string, error)
+	TokenForRepo(ctx context.Context, owner string, repo string, operation string) (string, error)
 }
 
 type ExecutorConfig struct {
@@ -56,21 +58,23 @@ func (e *HTTPExecutor) Execute(ctx context.Context, artifact *core.Artifact, ope
 	if err != nil {
 		return nil, err
 	}
-	token, err := e.tokenSource.TokenForRepo(ctx, owner, repo)
+	requestSpec, err := e.buildRequest(operation, owner, repo, params)
 	if err != nil {
 		return nil, err
 	}
-
-	requestURL, err := e.buildRequestURL(operation, owner, repo, params)
+	token, err := e.tokenSource.TokenForRepo(ctx, owner, repo, operation)
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	request, err := http.NewRequestWithContext(ctx, requestSpec.method, requestSpec.url, bytes.NewReader(requestSpec.body))
 	if err != nil {
 		return nil, err
 	}
 	request.Header.Set("Authorization", "Bearer "+token)
 	request.Header.Set("Accept", "application/vnd.github+json")
+	if len(requestSpec.body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
 
 	response, err := e.client.Do(request)
 	if err != nil {
@@ -89,33 +93,77 @@ func (e *HTTPExecutor) Execute(ctx context.Context, artifact *core.Artifact, ope
 	return body, nil
 }
 
-func (e *HTTPExecutor) buildRequestURL(operation string, owner string, repo string, params map[string]any) (string, error) {
+type requestSpec struct {
+	method string
+	url    string
+	body   []byte
+}
+
+func (e *HTTPExecutor) buildRequest(operation string, owner string, repo string, params map[string]any) (requestSpec, error) {
 	u, err := url.Parse(e.baseURL)
 	if err != nil {
-		return "", err
+		return requestSpec{}, err
 	}
 
 	switch operation {
-	case "pull_request_metadata":
+	case operationPullRequestMetadata:
 		u.Path = fmt.Sprintf("%s/repos/%s/%s/pulls/%d", u.Path, owner, repo, intFromAny(params["pull_number"]))
-	case "pull_request_files":
+	case operationPullRequestFiles:
 		u.Path = fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files", u.Path, owner, repo, intFromAny(params["pull_number"]))
 		q := u.Query()
 		q.Set("page", strconv.Itoa(max(intFromAny(params["page"]), 1)))
 		q.Set("per_page", strconv.Itoa(min(max(intFromAny(params["per_page"]), 1), 100)))
 		u.RawQuery = q.Encode()
-	case "repository_metadata":
+	case operationRepositoryMetadata:
 		u.Path = fmt.Sprintf("%s/repos/%s/%s", u.Path, owner, repo)
-	case "repository_issues":
+	case operationRepositoryIssues:
 		u.Path = fmt.Sprintf("%s/repos/%s/%s/issues", u.Path, owner, repo)
 		q := u.Query()
 		q.Set("page", strconv.Itoa(max(intFromAny(params["page"]), 1)))
 		q.Set("per_page", strconv.Itoa(min(max(intFromAny(params["per_page"]), 1), 100)))
 		u.RawQuery = q.Encode()
+	case operationCreateIssue:
+		u.Path = fmt.Sprintf("%s/repos/%s/%s/issues", u.Path, owner, repo)
+		body, err := marshalRequestBody(map[string]any{
+			"title":     params["title"],
+			"body":      params["body"],
+			"assignees": params["assignees"],
+			"labels":    params["labels"],
+		})
+		if err != nil {
+			return requestSpec{}, err
+		}
+		return requestSpec{method: http.MethodPost, url: u.String(), body: body}, nil
+	case operationCreatePullRequestComment:
+		u.Path = fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", u.Path, owner, repo, intFromAny(params["pull_number"]))
+		body, err := marshalRequestBody(map[string]any{
+			"body": params["body"],
+		})
+		if err != nil {
+			return requestSpec{}, err
+		}
+		return requestSpec{method: http.MethodPost, url: u.String(), body: body}, nil
+	case operationCreateCheckRun:
+		u.Path = fmt.Sprintf("%s/repos/%s/%s/check-runs", u.Path, owner, repo)
+		body, err := marshalRequestBody(map[string]any{
+			"name":         params["name"],
+			"head_sha":     params["head_sha"],
+			"details_url":  params["details_url"],
+			"external_id":  params["external_id"],
+			"status":       params["status"],
+			"conclusion":   params["conclusion"],
+			"started_at":   params["started_at"],
+			"completed_at": params["completed_at"],
+			"output":       params["output"],
+		})
+		if err != nil {
+			return requestSpec{}, err
+		}
+		return requestSpec{method: http.MethodPost, url: u.String(), body: body}, nil
 	default:
-		return "", fmt.Errorf("%w: github operation %q is not allowlisted", core.ErrForbidden, operation)
+		return requestSpec{}, fmt.Errorf("%w: github operation %q is not allowlisted", core.ErrForbidden, operation)
 	}
-	return u.String(), nil
+	return requestSpec{method: http.MethodGet, url: u.String()}, nil
 }
 
 func parseOwnerRepo(resourceRef string) (string, string, error) {
@@ -164,9 +212,23 @@ func max(a int, b int) int {
 
 type staticTokenSource string
 
-func (s staticTokenSource) TokenForRepo(context.Context, string, string) (string, error) {
+func (s staticTokenSource) TokenForRepo(context.Context, string, string, string) (string, error) {
 	if s == "" {
 		return "", fmt.Errorf("%w: github token is empty", core.ErrInvalidRequest)
 	}
 	return string(s), nil
+}
+
+func marshalRequestBody(payload map[string]any) ([]byte, error) {
+	filtered := make(map[string]any, len(payload))
+	for key, value := range payload {
+		if value == nil {
+			continue
+		}
+		filtered[key] = value
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(filtered)
 }

--- a/internal/connectors/github/executor_test.go
+++ b/internal/connectors/github/executor_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -90,6 +91,134 @@ func TestHTTPExecutor_ClassifiesGitHubAPIErrors(t *testing.T) {
 			}, "repository_metadata", nil)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("Execute() error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestHTTPExecutor_ExecuteWriteOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		operation  string
+		params     map[string]any
+		wantMethod string
+		wantPath   string
+		wantBody   map[string]any
+	}{
+		{
+			name:       "create issue",
+			operation:  "create_issue",
+			wantMethod: http.MethodPost,
+			wantPath:   "/repos/acme/widgets/issues",
+			params: map[string]any{
+				"title": "Bug report",
+				"body":  "Something broke",
+				"labels": []any{
+					"bug",
+				},
+			},
+			wantBody: map[string]any{
+				"title":  "Bug report",
+				"body":   "Something broke",
+				"labels": []any{"bug"},
+			},
+		},
+		{
+			name:       "create pull request comment",
+			operation:  "create_pull_request_comment",
+			wantMethod: http.MethodPost,
+			wantPath:   "/repos/acme/widgets/issues/142/comments",
+			params: map[string]any{
+				"pull_number": 142,
+				"body":        "Looks good to me",
+			},
+			wantBody: map[string]any{
+				"body": "Looks good to me",
+			},
+		},
+		{
+			name:       "create check run",
+			operation:  "create_check_run",
+			wantMethod: http.MethodPost,
+			wantPath:   "/repos/acme/widgets/check-runs",
+			params: map[string]any{
+				"name":     "ci/asb",
+				"head_sha": "abc123",
+				"status":   "completed",
+				"output": map[string]any{
+					"title":   "CI passed",
+					"summary": "All checks passed",
+				},
+			},
+			wantBody: map[string]any{
+				"name":     "ci/asb",
+				"head_sha": "abc123",
+				"status":   "completed",
+				"output": map[string]any{
+					"title":   "CI passed",
+					"summary": "All checks passed",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tc.wantMethod {
+					t.Fatalf("method = %q, want %q", r.Method, tc.wantMethod)
+				}
+				if r.URL.Path != tc.wantPath {
+					t.Fatalf("path = %q, want %q", r.URL.Path, tc.wantPath)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/json" {
+					t.Fatalf("content-type = %q, want application/json", got)
+				}
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("Decode() error = %v", err)
+				}
+				if len(body) != len(tc.wantBody) {
+					t.Fatalf("body keys = %v, want %v", body, tc.wantBody)
+				}
+				for key, value := range tc.wantBody {
+					got, ok := body[key]
+					if !ok {
+						t.Fatalf("body missing key %q in %#v", key, body)
+					}
+					if gotValue, _ := json.Marshal(got); string(gotValue) == "" {
+						t.Fatalf("body key %q encoded empty", key)
+					}
+					wantValue, _ := json.Marshal(value)
+					gotValue, _ := json.Marshal(got)
+					if string(gotValue) != string(wantValue) {
+						t.Fatalf("body[%q] = %s, want %s", key, string(gotValue), string(wantValue))
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer server.Close()
+
+			executor := github.NewHTTPExecutor(github.ExecutorConfig{
+				BaseURL:     server.URL,
+				Client:      server.Client(),
+				TokenSource: github.StaticTokenSource("test-token"),
+			})
+			payload, err := executor.Execute(context.Background(), &core.Artifact{
+				Metadata: map[string]string{
+					"resource_ref": "github:repo:acme/widgets",
+				},
+			}, tc.operation, tc.params)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if string(payload) != `{"ok":true}` {
+				t.Fatalf("payload = %s, want expected github json", string(payload))
 			}
 		})
 	}

--- a/internal/connectors/github/operations.go
+++ b/internal/connectors/github/operations.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	operationPullRequestMetadata      = "pull_request_metadata"
+	operationPullRequestFiles         = "pull_request_files"
+	operationRepositoryMetadata       = "repository_metadata"
+	operationRepositoryIssues         = "repository_issues"
+	operationCreateIssue              = "create_issue"
+	operationCreatePullRequestComment = "create_pull_request_comment"
+	operationCreateCheckRun           = "create_check_run"
+)
+
+var defaultOperations = []string{
+	operationPullRequestMetadata,
+	operationPullRequestFiles,
+	operationRepositoryMetadata,
+	operationRepositoryIssues,
+}
+
+var defaultReadPermissions = map[string]string{
+	"contents":      "read",
+	"issues":        "read",
+	"pull_requests": "read",
+}
+
+var supportedOperations = map[string]struct{}{
+	operationPullRequestMetadata:      {},
+	operationPullRequestFiles:         {},
+	operationRepositoryMetadata:       {},
+	operationRepositoryIssues:         {},
+	operationCreateIssue:              {},
+	operationCreatePullRequestComment: {},
+	operationCreateCheckRun:           {},
+}
+
+func normalizeOperations(operations []string) []string {
+	normalized := make([]string, 0, len(operations))
+	seen := make(map[string]struct{}, len(operations))
+	for _, operation := range operations {
+		trimmed := strings.TrimSpace(operation)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := supportedOperations[trimmed]; !ok {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func permissionsForOperation(operation string, readPermissions map[string]string) map[string]string {
+	switch operation {
+	case operationCreateIssue:
+		return map[string]string{"issues": "write"}
+	case operationCreatePullRequestComment:
+		return map[string]string{"issues": "write"}
+	case operationCreateCheckRun:
+		return map[string]string{"checks": "write"}
+	default:
+		if len(readPermissions) == 0 {
+			return clonePermissions(defaultReadPermissions)
+		}
+		return clonePermissions(readPermissions)
+	}
+}
+
+func permissionScopeKey(permissions map[string]string) string {
+	if len(permissions) == 0 {
+		return "none"
+	}
+	keys := make([]string, 0, len(permissions))
+	for key := range permissions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+permissions[key])
+	}
+	return strings.Join(parts, ",")
+}
+
+func clonePermissions(permissions map[string]string) map[string]string {
+	if len(permissions) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(permissions))
+	for key, value := range permissions {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/connectors/github/token_cache.go
+++ b/internal/connectors/github/token_cache.go
@@ -16,8 +16,8 @@ const defaultRepoInstallationTTL = 24 * time.Hour
 type AppTokenCache interface {
 	GetRepoInstallation(ctx context.Context, repoKey string) (int64, bool, error)
 	SetRepoInstallation(ctx context.Context, repoKey string, installationID int64) error
-	GetInstallationToken(ctx context.Context, installationID int64) (cachedInstallationToken, bool, error)
-	SetInstallationToken(ctx context.Context, installationID int64, token cachedInstallationToken) error
+	GetInstallationToken(ctx context.Context, installationID int64, scopeKey string) (cachedInstallationToken, bool, error)
+	SetInstallationToken(ctx context.Context, installationID int64, scopeKey string, token cachedInstallationToken) error
 }
 
 type RedisAppTokenCacheConfig struct {
@@ -75,8 +75,8 @@ func (c *redisAppTokenCache) SetRepoInstallation(ctx context.Context, repoKey st
 	).Err()
 }
 
-func (c *redisAppTokenCache) GetInstallationToken(ctx context.Context, installationID int64) (cachedInstallationToken, bool, error) {
-	value, err := c.client.Get(ctx, c.installationTokenKey(installationID)).Bytes()
+func (c *redisAppTokenCache) GetInstallationToken(ctx context.Context, installationID int64, scopeKey string) (cachedInstallationToken, bool, error) {
+	value, err := c.client.Get(ctx, c.installationTokenKey(installationID, scopeKey)).Bytes()
 	if err == goredis.Nil {
 		return cachedInstallationToken{}, false, nil
 	}
@@ -93,7 +93,7 @@ func (c *redisAppTokenCache) GetInstallationToken(ctx context.Context, installat
 	return cached, true, nil
 }
 
-func (c *redisAppTokenCache) SetInstallationToken(ctx context.Context, installationID int64, token cachedInstallationToken) error {
+func (c *redisAppTokenCache) SetInstallationToken(ctx context.Context, installationID int64, scopeKey string, token cachedInstallationToken) error {
 	ttl := time.Until(token.expiresAt)
 	if ttl <= 0 {
 		return nil
@@ -105,13 +105,13 @@ func (c *redisAppTokenCache) SetInstallationToken(ctx context.Context, installat
 	if err != nil {
 		return err
 	}
-	return c.client.Set(ctx, c.installationTokenKey(installationID), payload, ttl).Err()
+	return c.client.Set(ctx, c.installationTokenKey(installationID, scopeKey), payload, ttl).Err()
 }
 
 func (c *redisAppTokenCache) repoInstallationKey(repoKey string) string {
 	return fmt.Sprintf("%sgithub:repo-installation:%s", c.keyPrefix, repoKey)
 }
 
-func (c *redisAppTokenCache) installationTokenKey(installationID int64) string {
-	return fmt.Sprintf("%sgithub:installation-token:%d", c.keyPrefix, installationID)
+func (c *redisAppTokenCache) installationTokenKey(installationID int64, scopeKey string) string {
+	return fmt.Sprintf("%sgithub:installation-token:%d:%s", c.keyPrefix, installationID, scopeKey)
 }

--- a/internal/connectors/github/token_source.go
+++ b/internal/connectors/github/token_source.go
@@ -25,13 +25,13 @@ type fallbackTokenSource struct {
 	fallback RepoTokenSource
 }
 
-func (s fallbackTokenSource) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
-	token, err := s.primary.TokenForRepo(ctx, owner, repo)
+func (s fallbackTokenSource) TokenForRepo(ctx context.Context, owner string, repo string, operation string) (string, error) {
+	token, err := s.primary.TokenForRepo(ctx, owner, repo, operation)
 	if err == nil {
 		return token, nil
 	}
 
-	fallbackToken, fallbackErr := s.fallback.TokenForRepo(ctx, owner, repo)
+	fallbackToken, fallbackErr := s.fallback.TokenForRepo(ctx, owner, repo, operation)
 	if fallbackErr != nil {
 		return "", fmt.Errorf("%w: primary token source failed: %v; fallback token source failed: %v", core.ErrUnauthorized, err, fallbackErr)
 	}

--- a/internal/connectors/github/token_source_test.go
+++ b/internal/connectors/github/token_source_test.go
@@ -12,15 +12,15 @@ func TestFallbackTokenSourceUsesFallbackOnPrimaryFailure(t *testing.T) {
 	t.Parallel()
 
 	source := github.FallbackTokenSource(
-		repoTokenSourceFunc(func(context.Context, string, string) (string, error) {
+		repoTokenSourceFunc(func(context.Context, string, string, string) (string, error) {
 			return "", errors.New("app token exchange failed")
 		}),
-		repoTokenSourceFunc(func(context.Context, string, string) (string, error) {
+		repoTokenSourceFunc(func(context.Context, string, string, string) (string, error) {
 			return "static-token", nil
 		}),
 	)
 
-	token, err := source.TokenForRepo(context.Background(), "acme", "widgets")
+	token, err := source.TokenForRepo(context.Background(), "acme", "widgets", "repository_metadata")
 	if err != nil {
 		t.Fatalf("TokenForRepo() error = %v", err)
 	}
@@ -29,8 +29,8 @@ func TestFallbackTokenSourceUsesFallbackOnPrimaryFailure(t *testing.T) {
 	}
 }
 
-type repoTokenSourceFunc func(context.Context, string, string) (string, error)
+type repoTokenSourceFunc func(context.Context, string, string, string) (string, error)
 
-func (fn repoTokenSourceFunc) TokenForRepo(ctx context.Context, owner string, repo string) (string, error) {
-	return fn(ctx, owner, repo)
+func (fn repoTokenSourceFunc) TokenForRepo(ctx context.Context, owner string, repo string, operation string) (string, error) {
+	return fn(ctx, owner, repo, operation)
 }

--- a/internal/connectors/vaultdb/client.go
+++ b/internal/connectors/vaultdb/client.go
@@ -65,7 +65,9 @@ func (c *HTTPClient) GenerateCredentials(ctx context.Context, role string) (*Lea
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
@@ -115,7 +117,9 @@ func (c *HTTPClient) revokeLeaseOnce(ctx context.Context, leaseID string) error 
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 	payload, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err

--- a/internal/crypto/sessionjwt/manager.go
+++ b/internal/crypto/sessionjwt/manager.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/evalops/asb/internal/core"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type Manager struct {
@@ -80,7 +80,7 @@ func (m *Manager) Verify(raw string) (*core.SessionClaims, error) {
 }
 
 func (c *claims) Valid() error {
-	if c.RegisteredClaims.ExpiresAt == nil {
+	if c.ExpiresAt == nil {
 		return fmt.Errorf("%w: missing exp", core.ErrUnauthorized)
 	}
 	return jwt.NewValidator(jwt.WithTimeFunc(time.Now)).Validate(c.RegisteredClaims)


### PR DESCRIPTION
## Summary
- add opt-in GitHub proxy write operations for issue creation, PR conversation comments, and check runs
- scope GitHub App installation tokens per operation and cache them by permission scope instead of by installation alone
- add `ASB_GITHUB_ALLOWED_OPERATIONS` and tighten the remaining repo-wide lint blockers so ASB stays green

## Testing
- go test ./internal/connectors/github -count=1
- go test ./internal/bootstrap -count=1
- go test ./... -count=1
- GOTOOLCHAIN=go1.26.0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...

Closes #12
